### PR TITLE
Fallback to use root for graphite

### DIFF
--- a/inventory/service/group_vars/graphite.yaml
+++ b/inventory/service/group_vars/graphite.yaml
@@ -1,6 +1,7 @@
-graphite_os_user: graphite
-graphite_os_group: graphite
+graphite_sync_user: graphite
+graphite_sync_group: graphite
+
 graphite_relay_replication_factor: 2
 firewalld_extra_services_enable: ['http', 'https']
 firewalld_extra_ports_enable: ['2003/tcp', '2004/tcp', '2013/tcp', '2014/tcp',
-  '2023/tcp', '2024/tcp', '8125/udp', '8081/tcp']
+  '2023/tcp', '2024/tcp', '8125/udp']

--- a/inventory/service/groups.yaml
+++ b/inventory/service/groups.yaml
@@ -85,4 +85,6 @@ groups:
     - bridge.eco.tsi-dev.otc-service.com
   control-plane-clouds:
     - bridge.eco.tsi-dev.otc-service.com
-  disabled: []
+  disabled:
+    # We can not manage coreos with ansible by default
+    - graphite1.apimon.eco.tsi-dev.otc-service.com

--- a/playbooks/roles/graphite/defaults/main.yaml
+++ b/playbooks/roles/graphite/defaults/main.yaml
@@ -1,5 +1,5 @@
-graphite_os_user: graphite
-graphite_os_group: graphite
+graphite_sync_user: graphite
+graphite_sync_group: graphite
 
 graphite_config_location: "/etc/graphite"
 graphite_retentions_carbon: "60:90d"

--- a/playbooks/roles/graphite/tasks/main.yaml
+++ b/playbooks/roles/graphite/tasks/main.yaml
@@ -19,42 +19,36 @@
   until: task_result is success
   retries: 5
 
-- name: Create graphite group
+- name: Create graphite sync group
   become: yes
   ansible.builtin.group:
-    name: "{{ graphite_os_group }}"
+    name: "{{ graphite_sync_group }}"
     state: present
 
-- name: Create graphite user
+- name: Create graphite sync user
   become: true
   ansible.builtin.user:
-    name: "{{ graphite_os_user }}"
-    group: "{{ graphite_os_group }}"
+    name: "{{ graphite_sync_user }}"
+    group: "{{ graphite_sync_group }}"
     state: present
 
 - name: Add graphite user authorized key
   ansible.posix.authorized_key:
-    user: "{{ graphite_os_user }}"
+    user: "{{ graphite_sync_user }}"
     key: "{{ graphite_public_key }}"
     state: "present"
 
 - name: Write private key when not root
   ansible.builtin.copy:
     content: "{{ graphite_private_key }}"
-    dest: "/home/{{ graphite_os_user }}/.ssh/id_rsa"
-    owner: "{{ graphite_os_user }}"
-    group: "{{ graphite_os_group }}"
+    dest: "/root/.ssh/id_rsa.graphite"
     mode: "0400"
-  when:
-    - "graphite_os_user != 'root'"
 
 - name: Ensure directories exist
   become: true
   ansible.builtin.file:
     state: "directory"
     path: "{{ item }}"
-    owner: "{{ graphite_os_user }}"
-    group: "{{ graphite_os_group }}"
     mode: "0755"
   loop:
     - "{{ graphite_config_location }}"
@@ -66,8 +60,6 @@
   ansible.builtin.template:
     src: "{{ item }}.j2"
     dest: "{{ graphite_config_location }}//{{ item }}"
-    owner: "{{ graphite_os_user }}"
-    group: "{{ graphite_os_group }}"
     mode: "0644"
   loop:
     - "storage-schemas.conf"

--- a/playbooks/roles/graphite/templates/env.j2
+++ b/playbooks/roles/graphite/templates/env.j2
@@ -6,3 +6,7 @@ REDIS_TAGDB=0
 {% if graphite_cluster_servers is defined and graphite_cluster_servers|length %}
 GRAPHITE_CLUSTER_SERVERS={{ graphite_cluster_servers }}
 {% endif %}
+GRAPHITE_LOG_FILE_INFO="-"
+GRAPHITE_LOG_FILE_EXCEPTION="-"
+GRAPHITE_LOG_FILE_CACHE="-"
+GRAPHITE_LOG_FILE_RENDERING="-"

--- a/playbooks/roles/graphite/templates/graphite-statsd.conf.j2
+++ b/playbooks/roles/graphite/templates/graphite-statsd.conf.j2
@@ -7,8 +7,8 @@
 #}
 
 server {
-  listen 8081 default_server;
-  listen [::]:8081 default_server;
+  listen 80 default_server;
+  listen [::]:80 default_server;
   server_name _;
 
 #  listen 443 ssl;

--- a/playbooks/roles/graphite/templates/graphite.service.j2
+++ b/playbooks/roles/graphite/templates/graphite.service.j2
@@ -6,10 +6,6 @@ After=syslog.target network.target
 Restart=always
 ExecStartPre=-{{ container_runtime }} kill graphite
 ExecStartPre=-{{ container_runtime }} rm graphite
-{% if graphite_os_user != 'root' %}
-User={{ graphite_os_user }}
-Group={{ graphite_os_group }}
-{% endif %}
 
 ExecStart={{ container_runtime }} run \
     --name graphite \

--- a/playbooks/service-graphite.yaml
+++ b/playbooks/service-graphite.yaml
@@ -31,15 +31,25 @@
       ansible.builtin.file:
         dest: "/opt/graphite/conf"
         state: "directory"
-        owner: "{{ graphite_os_user | default(omit) }}"
-        group: "{{ graphite_os_group | default(omit) }}"
+
+    - name: Create /root/bin directory
+      ansible.builtin.file:
+        dest: "/root/bin"
+        state: "directory"
 
     - name: Write carbonate config
       ansible.builtin.copy:
         content: "{{ lookup('template', 'templates/graphite/carbonate.conf.j2') }}"
         dest: "/opt/graphite/conf/carbonate.conf"
-        owner: "{{ graphite_os_user | default(omit) }}"
-        group: "{{ graphite_os_group | default(omit) }}"
+
+    - name: Write carbonate tool scrips
+      ansible.builtin.copy:
+        content: "{{ lookup('template', 'templates/graphite/' + item + '.j2') }}"
+        dest: "/root/bin/{{ item }}"
+        mode: "0755"
+      loop:
+        - "graphite_resync_node.sh"
+        - "graphite_list_foreign_metrics.sh"
 
     - name: Install carbonate tools
       ansible.builtin.pip:

--- a/playbooks/templates/graphite/carbonate.conf.j2
+++ b/playbooks/templates/graphite/carbonate.conf.j2
@@ -7,3 +7,7 @@ REPLICATION_FACTOR = {{ graphite_relay_replication_factor }}
 {% else %}
 REPLICATION_FACTOR = 1
 {% endif %}
+RELAY_METHOD=consistent-hashring
+{% if graphite_sync_user is defined %}
+SSH_USER={{ graphite_sync_user }}
+{% endif %}

--- a/playbooks/templates/graphite/graphite_list_foreign_metrics.sh.j2
+++ b/playbooks/templates/graphite/graphite_list_foreign_metrics.sh.j2
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# List metrics from disk that don't belong
+#
+
+LOCAL_IP="$1"
+
+carbon-list | carbon-sieve -I -n $LOCAL_IP

--- a/playbooks/templates/graphite/graphite_resync_node.sh.j2
+++ b/playbooks/templates/graphite/graphite_resync_node.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Resync a node from other nodes in the cluster
+#
+
+LOCAL_IP="$1"
+
+for h in $(carbon-hosts) ; do
+  (
+    ssh {{ graphite_sync_user }}@$h -i "/root/.ssh/id_rsa.graphite" -- carbon-list |
+    carbon-sieve -n $LOCAL_IP |
+    carbon-sync -s $h
+  ) &
+done

--- a/playbooks/zuul/templates/group_vars/graphite.yaml.j2
+++ b/playbooks/zuul/templates/group_vars/graphite.yaml.j2
@@ -1,5 +1,5 @@
-graphite_os_user: root
-graphite_os_group: root
+graphite_sync_user: graphite
+graphite_sync_group: graphite
 graphite_instance_group: graphite-inst1
 graphite_relay_replication_factor: 2
 
@@ -13,4 +13,4 @@ graphite_private_key: |
 
 firewalld_extra_services_enable: ['http', 'https']
 firewalld_extra_ports_enable: ['2003/tcp', '2004/tcp', '2013/tcp', '2014/tcp',
-  '2023/tcp', '2024/tcp', '8125/udp', '8081/tcp']
+  '2023/tcp', '2024/tcp', '8125/udp']

--- a/testinfra/test_graphite.py
+++ b/testinfra/test_graphite.py
@@ -20,7 +20,7 @@ testinfra_hosts = ['graphite1.focal', 'graphite2.centos']
 
 
 def test_graphite_container_web_listening(host):
-    graphite_http = host.socket("tcp://0.0.0.0:8081")
+    graphite_http = host.socket("tcp://0.0.0.0:80")
     assert graphite_http.is_listening
 
     #graphite_https = host.socket("tcp://127.0.0.1:443")
@@ -28,8 +28,8 @@ def test_graphite_container_web_listening(host):
 
 def test_graphite(host):
     cmd = host.run('curl --insecure '
-                   '--resolve graphite1.focal:8081:127.0.0.1 '
-                   'http://graphite1.focal:8081')
+                   '--resolve graphite1.focal:80:127.0.0.1 '
+                   'http://graphite1.focal:80')
     assert '<title>Graphite Browser</title>' in cmd.stdout
 
 def test_graphite_data(host):
@@ -45,7 +45,7 @@ def test_graphite_data(host):
     # multi-node-hosts-file has setup graphite1.focal to
     # resolve from hosts.
     found_value = False
-    with urllib.request.urlopen('http://graphite1.focal:8081/%s' % (url),
+    with urllib.request.urlopen('http://graphite1.focal:80/%s' % (url),
 #                                context=ssl._create_unverified_context()
                                ) \
                                 as req:

--- a/zuul.d/system-config-run.yaml
+++ b/zuul.d/system-config-run.yaml
@@ -158,13 +158,6 @@
     vars:
       run_playbooks:
         - playbooks/service-graphite.yaml
-    host-vars:
-      graphite1.focal:
-        graphite_os_user: root
-        graphite_os_group: root
-      graphite2.centos:
-        graphite_os_user: graphite
-        graphite_os_group: graphite
     files:
       - tox.ini
       - playbooks/service-graphite.yaml


### PR DESCRIPTION
- slight change in graphite configs
- fallback to using root for graphite
- Graphite container doesn't really want to be running as non root container with tons of problems. Let's run it as root, but add a separate user for sync
