### PR TITLE
Fix compute dashboard

### DIFF
--- a/playbooks/templates/grafana/apimon/_kpi_compute.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_kpi_compute.yaml.j2
@@ -111,7 +111,7 @@
       - queryType: randomWalk
         refId: A
         target: groupByNode(stats.timers.apimon.metric.$environment.$zone.create_server.{default,eu*}.*.upper,
-          7, 'sum')
+          7, 'avg')
     title: Boot time duration (F30)
     type: stat
 
@@ -138,6 +138,6 @@
     targets:
       - queryType: randomWalk
         refId: A
-        target: groupByNode(stats.timers.apimon.metric.$environment.$zone.create_server_coreos.{default,eu*}.*.upper, 7, 'sum')
+        target: groupByNode(stats.timers.apimon.metric.$environment.$zone.create_server_coreos.{default,eu*}.*.upper, 7, 'avg')
     title: Boot time duration (CoreOS)
     type: stat

--- a/playbooks/templates/grafana/apimon/compute.yaml.j2
+++ b/playbooks/templates/grafana/apimon/compute.yaml.j2
@@ -26,7 +26,7 @@ panels:
     targets:
       - refId: A
         target: groupByNode(stats.timers.apimon.metric.$environment.$zone.create_server.{default,eu*}.*.mean_90,
-          7, 'sum')
+          7, 'avg')
     title: Instance Boot duration (Fedora30)
     type: graph
     xaxis:
@@ -104,7 +104,7 @@ panels:
     targets:
       - refId: A
         target: groupByNode(stats.timers.apimon.metric.$environment.$zone.create_server_coreos.{default,eu*}.*.mean_90,
-          7, 'sum')
+          7, 'avg')
     title: Instance Boot duration (coreos)
     type: graph
     xaxis:

--- a/playbooks/templates/grafana/apimon/compute.yaml.j2
+++ b/playbooks/templates/grafana/apimon/compute.yaml.j2
@@ -80,7 +80,7 @@ panels:
     repeatDirection: h
     targets:
       - refId: A
-        target: aliasByMetric(summarize(groupByNode(stats.counters.apimon.metric.$environment.$zone.create_server.{default,eu*}.passed.count,
+        target: aliasByMetric(summarize(groupByNode(stats.counters.apimon.metric.$environment.$zone.{create_server,create_server_coreos}.{default,eu*}.passed.count,
           7, 'sum'), '1d', 'sum', false))
     title: SSH Successful Logins
     type: gauge

--- a/zuul.d/infra-prod.yaml
+++ b/zuul.d/infra-prod.yaml
@@ -244,4 +244,13 @@
       - playbooks/service-proxy.yaml
       - roles/haproxy/
 
-
+- job:
+    name: infra-prod-dashboards
+    parent: infra-prod-service-base
+    description: Run dashboards.yaml playbook.
+    vars:
+      playbook_name: dashboards.yaml
+    files:
+      - inventory/
+      - playbooks/dashboards.yaml
+      - playbooks/templates/grafana

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -51,6 +51,7 @@
         - infra-prod-service-alerta-k8s
         - infra-prod-service-grafana
         - infra-prod-service-proxy
+        - infra-prod-dashboards
     periodic:
       # Nightly execution
       jobs:


### PR DESCRIPTION
When selecting multiple zones server provisioning duration was summed
and not averaged.
While being on that enable automatic deployment of dashboards in deploy
pipeline.