### PR TITLE
Add privilege elevation to most playbooks

### DIFF
--- a/inventory/service/groups.yaml
+++ b/inventory/service/groups.yaml
@@ -125,6 +125,7 @@ groups:
     - bridge.eco.tsi-dev.otc-service.com
     - graphite1.apimon.eco.tsi-dev.otc-service.com
     - graphite2.apimon.eco.tsi-dev.otc-service.com
+    - graphite3.apimon.eco.tsi-dev.otc-service.com
     - graphite1.eco.tsi-dev.otc-service.com
     - proxy1.eco.tsi-dev.otc-service.com
     - proxy2.eco.tsi-dev.otc-service.com
@@ -148,7 +149,7 @@ groups:
 
   disabled:
     # We can not manage coreos with ansible by default
-    - graphite1.apimon.eco.tsi-dev.otc-service.com
+    # - graphite1.apimon.eco.tsi-dev.otc-service.com
     # ZK are not yet managed by SC
     - zk0.zuul.eco.tsi-dev.otc-service.com
     - zk1.zuul.eco.tsi-dev.otc-service.com

--- a/playbooks/acme-certs.yaml
+++ b/playbooks/acme-certs.yaml
@@ -1,4 +1,5 @@
 - hosts: ssl_certs:!disabled
+  become: true
   roles:
     - acme_request_certs
 
@@ -7,6 +8,7 @@
     - acme_install_txt_records
 
 - hosts: ssl_certs:!disabled
+  become: true
   roles:
     - acme_create_certs
 

--- a/playbooks/service-alerta.yaml
+++ b/playbooks/service-alerta.yaml
@@ -1,4 +1,5 @@
 - hosts: "alerta-vm:!disabled"
+  become: true
   name: "Base: configure alerta"
   vars:
     alerta: "{{ alerta_instances[alerta_instance] | combine(alerta_instances_secrets[alerta_instance], recursive=True) }}"

--- a/playbooks/service-apimon-epmon.yaml
+++ b/playbooks/service-apimon-epmon.yaml
@@ -1,4 +1,5 @@
 - hosts: apimon-epmon:!disabled
+  become: true
   name: "Configure APImon Endpoint monitoring service"
   vars:
     apimon: "{{ apimon_instances[apimon_instance] | combine(apimon_instances_secrets[apimon_instance], recursive=True) }}"

--- a/playbooks/service-apimon-executor.yaml
+++ b/playbooks/service-apimon-executor.yaml
@@ -1,4 +1,5 @@
 - hosts: apimon-executor:!disabled
+  become: true
   name: "Configure APImon Executor service"
   vars:
     apimon: "{{ apimon_instances[apimon_instance] | combine(apimon_instances_secrets[apimon_instance], recursive=True) }}"

--- a/playbooks/service-apimon-scheduler.yaml
+++ b/playbooks/service-apimon-scheduler.yaml
@@ -1,4 +1,5 @@
 - hosts: apimon-scheduler:!disabled
+  become: true
   name: "Configure APImon Scheduler service"
   vars:
     apimon: "{{ apimon_instances[apimon_instance] | combine(apimon_instances_secrets[apimon_instance], recursive=True) }}"

--- a/playbooks/service-bridge.yaml
+++ b/playbooks/service-bridge.yaml
@@ -1,4 +1,5 @@
 - hosts: bridge.eco.tsi-dev.otc-service.com:!disabled
+  become: true
   name: "Bridge: configure the bastion host"
   roles:
     #- iptables

--- a/playbooks/service-grafana.yaml
+++ b/playbooks/service-grafana.yaml
@@ -1,4 +1,5 @@
 - hosts: "grafana-vm:!disabled"
+  become: true
   name: "Base: configure grafana"
   vars:
     grafana: "{{ grafana_instances[grafana_instance] | combine(grafana_instances_secrets[grafana_instance], recursive=True) }}"

--- a/playbooks/service-graphite.yaml
+++ b/playbooks/service-graphite.yaml
@@ -1,5 +1,6 @@
 - hosts: "graphite:!disabled"
   name: "Base: configure graphite"
+  become: true
   roles:
     # Group should be responsible for defining open ports
     - firewalld

--- a/playbooks/service-memcached.yaml
+++ b/playbooks/service-memcached.yaml
@@ -1,5 +1,6 @@
 - hosts: "memcached:!disabled"
   name: "Base: configure memcached"
+  become: true
   roles:
     # Group should be responsible for defining open ports
     - firewalld

--- a/playbooks/service-proxy.yaml
+++ b/playbooks/service-proxy.yaml
@@ -1,4 +1,5 @@
 - hosts: "proxy:!disabled"
+  become: true
   name: "Base: configure proxy instances"
   roles:
     # Group should be responsible for defining open ports

--- a/playbooks/service-statsd.yaml
+++ b/playbooks/service-statsd.yaml
@@ -1,4 +1,5 @@
 - hosts: statsd:!disabled
+  become: true
   name: "Configure StatsD service"
   roles:
     - statsd

--- a/playbooks/set-hostnames.yaml
+++ b/playbooks/set-hostnames.yaml
@@ -1,4 +1,5 @@
 - hosts: "!disabled"
+  become: true
   gather_facts: false
   roles:
     - set-hostname

--- a/playbooks/x509-certs.yaml
+++ b/playbooks/x509-certs.yaml
@@ -1,4 +1,5 @@
 - hosts: bridge.eco.tsi-dev.otc-service.com:!disabled
+  become: true
   tasks:
     - include_role:
         name: "x509_cert"


### PR DESCRIPTION
Since we start supporting ssh not as root we need to consistently
elevate privileges (become root) in most of the playbooks where it is
necessary.