### PR TITLE
Fix dashboards for carbonapi

### DIFF
--- a/playbooks/dashboards.yaml
+++ b/playbooks/dashboards.yaml
@@ -6,6 +6,7 @@
       vars:
         grafana_dashboard_content: "{{ lookup('template', 'templates/grafana/' + item + '.j2') | from_yaml }}"
         grafana_dashboard_folder: "Apimon"
+        grafana_ds: "apimon-carbonapi"
       loop:
         - apimon/test_results.yaml
         - apimon/endpoint_monitor.yaml

--- a/playbooks/templates/grafana/apimon/_kpi_block_storage.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_kpi_block_storage.yaml.j2
@@ -147,9 +147,9 @@
       - queryType: randomWalk
         refCount: 0
         refId: A
-        target: alias(asPercent(sumSeries(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_volume.{default,eu*}.passed.count),
+        target: consolidateBy(asPercent(sumSeries(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_volume.{default,eu*}.passed.count),
           stats.counters.apimon.metric.$environment.$zone.create_volume.{default,eu*}.attempted.count)),
-          'Percentage')
+          'avg')
         textEditor: false
     title: Volume creation success rate
     type: stat
@@ -229,9 +229,9 @@
       - queryType: randomWalk
         refCount: 0
         refId: A
-        target: alias(asPercent(sumSeries(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_volume_snapshot.passed.count),
+        target: consolidateBy(asPercent(sumSeries(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_volume_snapshot.passed.count),
           stats.counters.apimon.metric.$environment.$zone.create_volume_snapshot.{default,eu*}.attempted.count)),
-          'Percentage')
+          'avg')
         textEditor: true
     title: Volume snapshot success rate
     type: stat
@@ -312,9 +312,9 @@
       - queryType: randomWalk
         refCount: 0
         refId: A
-        target: alias(asPercent(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_volume_backup.{default,eu*}.passed.count),
+        target: consolidateBy(asPercent(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_volume_backup.{default,eu*}.passed.count),
           sumSeries(stats.counters.apimon.metric.$environment.$zone.create_volume_backup.{default,eu*}.attempted.count)),
-          'Percentage')
+          'avg')
         textEditor: false
     title: Backup creation success rate
     type: stat

--- a/playbooks/templates/grafana/apimon/_kpi_cce.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_kpi_cce.yaml.j2
@@ -84,8 +84,8 @@
     targets:
       - queryType: randomWalk
         refId: A
-        target: asPercent(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_cce_cluster.passed.count),
-          sumSeries(stats.counters.apimon.metric.$environment.$zone.create_cce_cluster.attempted.count))
+        target: consolidateBy(asPercent(sumSeries(stats.counters.apimon.metric.$environment.$zone.create_cce_cluster.passed.count),
+          sumSeries(stats.counters.apimon.metric.$environment.$zone.create_cce_cluster.attempted.count)), 'avg')
         textEditor: true
     title: CCE Cluster provisioning success rate
     type: stat
@@ -125,8 +125,8 @@
       - queryType: randomWalk
         refCount: 0
         refId: A
-        target: asPercent(sumSeries(stats.counters.apimon.metric.$environment.$zone.delete_cce_cluster.passed.count),
-          sumSeries(stats.counters.apimon.metric.$environment.$zone.delete_cce_cluster.attempted.count))
+        target: consolidateBy(asPercent(sumSeries(stats.counters.apimon.metric.$environment.$zone.delete_cce_cluster.passed.count),
+          sumSeries(stats.counters.apimon.metric.$environment.$zone.delete_cce_cluster.attempted.count)), 'avg')
         textEditor: true
     title: CCE Cluster deletion success rate
     type: stat

--- a/playbooks/templates/grafana/apimon/_kpi_image.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_kpi_image.yaml.j2
@@ -187,9 +187,9 @@
       - queryType: randomWalk
         refCount: 0
         refId: A
-        target: aliasByNode(asPercent(stats.counters.apimon.metric.$environment.$zone.image_upload.passed.count,
+        target: aliasByNode(consolidateBy(asPercent(stats.counters.apimon.metric.$environment.$zone.image_upload.passed.count,
           stats.counters.apimon.metric.$environment.$zone.image_upload.attempted.count),
-          5)
+          'avg'), 5)
         textEditor: false
     title: SLI Image Upload success rate
     type: stat

--- a/playbooks/templates/grafana/apimon/_template_env.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_template_env.yaml.j2
@@ -4,12 +4,12 @@
         text: production_eu-de
         value: production_eu-de
       datasource: {{ grafana_ds | default('apimon') }}
-      definition: stats.counters.openstack.api.*
+      definition: stats.counters.apimon.metric.*
       includeAll: false
       label: Environment
       multi: false
       name: environment
-      query: stats.counters.openstack.api.*
+      query: stats.counters.apimon.metric.*
       refresh: 1
       regex: /^(?!swift)(.*)$/
       skipUrlSync: false

--- a/playbooks/templates/grafana/apimon/_template_zone.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_template_zone.yaml.j2
@@ -4,10 +4,10 @@
         text: production_eu-de
         value: production_eu-de
       datasource: {{ grafana_ds | default('apimon') }}
-      definition: stats.counters.openstack.api.*.*
+      definition: stats.counters.apimon.metric.*.*
       label: Monitoring source
       name: zone
-      query: stats.counters.openstack.api.*.*
+      query: stats.counters.apimon.metric.*.*
       refresh: 1
       regex: /^(?!swift)(.*)$/
       skipUrlSync: false

--- a/playbooks/templates/grafana/apimon/endpoint_monitor.yaml.j2
+++ b/playbooks/templates/grafana/apimon/endpoint_monitor.yaml.j2
@@ -37,9 +37,9 @@ panels:
       - hide: false
         refCount: 0
         refId: A
-        target: aliasByNode(summarize(applyByNode(stats.timers.openstack.api.$environment.$zone.*.*.*.*.count,
+        target: aliasByMetric(summarize(groupByNode(applyByNode(stats.timers.openstack.api.$environment.$zone.*.*.*.*.count,
           6, "asPercent(sumSeries(%.*.*.{2*,3*,404}.count), sumSeries(%.*.*.*.count))",
-          "%.pct"), '1hour', 'avg'), 6)
+          "%.pct"), 6, 'avg'), '1hour', 'avg'))
         textEditor: true
     title: Endpoint status
     transparent: true

--- a/playbooks/templates/grafana/apimon/kpi.yaml.j2
+++ b/playbooks/templates/grafana/apimon/kpi.yaml.j2
@@ -46,10 +46,10 @@ panels:
     targets:
       - queryType: randomWalk
         refId: A
-        target: asPercent(sumSeries(group(exclude(stats.counters.openstack.api.$environment.$zone.*.*.*.{2*,3*,404}.count,
+        target: consolidateBy(asPercent(sumSeries(group(exclude(stats.counters.openstack.api.$environment.$zone.*.*.*.{2*,3*,404}.count,
           'modelarts|tms|bms'), stats.counters.openstack.api.$environment.$zone.dns.GET.zone.400.count)),
-          sumSeries(exclude(stats.counters.openstack.api.$environment.$zone.*.*.*.{2*,3*,4*,5*,failed}.count,
-          'modelarts|tms|bms')))
+          sumSeries(exclude(stats.counters.openstack.api.$environment.$zone.*.*.*.attempted.count,
+          'modelarts|tms|bms'))), 'avg')
         textEditor: true
     title: SLI Service API Availability
     type: stat
@@ -252,10 +252,10 @@ panels:
     targets:
       - queryType: randomWalk
         refId: A
-        target: movingAverage(asPercent(sumSeries(group(exclude(stats.counters.openstack.api.$environment.$zone.*.*.*.{2*,3*,404}.count,
+        target: movingAverage(consolidateBy(asPercent(sumSeries(group(exclude(stats.counters.openstack.api.$environment.$zone.*.*.*.{2*,3*,404}.count,
           'modelarts|tms|bms'), stats.counters.openstack.api.$environment.$zone.dns.GET.zone.400.count)),
           sumSeries(exclude(stats.counters.openstack.api.$environment.$zone.*.*.*.attempted.count,
-          'modelarts|tms|bms'))), '7d')
+          'modelarts|tms|bms'))), 'avg'), '7d')
         textEditor: true
     title: SLO Service Availability
     type: stat

--- a/playbooks/templates/grafana/apimon/macros.j2
+++ b/playbooks/templates/grafana/apimon/macros.j2
@@ -28,8 +28,8 @@ gridPos: {x: {{ x }}, y: {{ y }}, h: {{ h }}, w: {{ w }} }
     targets:
       - refCount: 0
         refId: A
-        target: asPercent(sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.*.*.{{ '{' }}{{ status_codes | join(',') }}{{ '}' }}.count),
-          sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.*.*.attempted.count))
+        target: consolidateBy(asPercent(sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.*.*.{{ '{' }}{{ status_codes | join(',') }}{{ '}' }}.count),
+          sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.*.*.attempted.count)), 'average')
         textEditor: true
     title: SLI {{ svc_name }} service availability
     type: stat
@@ -64,8 +64,8 @@ gridPos: {x: {{ x }}, y: {{ y }}, h: {{ h }}, w: {{ w }} }
     targets:
       - queryType: randomWalk
         refId: A
-        target: asPercent(sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.{DELETE,PATCH,POST,PUT}.*.{{ '{' }}{{ status_codes | join(',') }}{{ '}' }}.count),
-          sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.{DELETE,PATCH,POST,PUT}.*.attempted.count))
+        target: consolidateBy(asPercent(sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.{DELETE,PATCH,POST,PUT}.*.{{ '{' }}{{ status_codes | join(',') }}{{ '}' }}.count),
+          sumSeries(stats.counters.openstack.api.$environment.$zone.{{ svc }}.{DELETE,PATCH,POST,PUT}.*.attempted.count)), 'average')
         textEditor: true
     title: SLI {{ svc_name }} write API Success rate
     type: stat


### PR DESCRIPTION
some finetuning of the dashboards to work well with carbonapi. Reverse
compatibility is not guaranteed, therefore merging this asumes switching
generally to carbonapi.
graphiteweb app remains.