### PR TITLE
Fix base role

### DIFF
--- a/playbooks/roles/base/server/tasks/main.yaml
+++ b/playbooks/roles/base/server/tasks/main.yaml
@@ -5,7 +5,7 @@
 
 - name: Install fallback packages
   ansible.builtin.package:
-    status: "present"
+    state: "present"
     name: "{{ item }}"
   ignore_errors: true
   loop:
@@ -29,6 +29,13 @@
     content: '$MaxMessageSize 6k'
     dest: /etc/rsyslog.d/99-maxsize.conf
     mode: 0644
+  notify: Restart rsyslog
+
+- name: Enable logs compression in logrotate
+  ansible.builtin.lineinfile:
+    path: "/etc/logrotate.conf"
+    regexp: "^#compress"
+    line: "compress"
   notify: Restart rsyslog
 
 - name: Ensure rsyslog is running


### PR DESCRIPTION
- fix wrong parameter name in the fallback package installations
- enable compression of the logrotate logs to try to use less space
