### PR TITLE
Limit maximal log file size

### DIFF
--- a/playbooks/roles/base/server/defaults/main.yaml
+++ b/playbooks/roles/base/server/defaults/main.yaml
@@ -14,3 +14,4 @@ base_packages:
   - strace
   - tcpdump
   - wget
+logrotate_maxsize: "300M"

--- a/playbooks/roles/base/server/tasks/main.yaml
+++ b/playbooks/roles/base/server/tasks/main.yaml
@@ -38,6 +38,14 @@
     line: "compress"
   notify: Restart rsyslog
 
+- name: Limit log size in logrotate
+  ansible.builtin.lineinfile:
+    path: "/etc/logrotate.conf"
+    regexp: "maxsize"
+    line: "maxsize: {{ logrotate_maxsize }}"
+  when: "logrotate_maxsize is defined"
+  notify: Restart rsyslog
+
 - name: Ensure rsyslog is running
   service:
     name: rsyslog


### PR DESCRIPTION
set maxsize in logrotate options (default 300M)
