### PR TITLE
Test proxy changes in inventory

### DIFF
--- a/inventory/service/group_vars/proxy.yaml
+++ b/inventory/service/group_vars/proxy.yaml
@@ -105,3 +105,5 @@ proxy_frontends:
 
 statsd_host: "192.168.14.159"
 statsd_port: "8125"
+
+haproxy_expose_ports: ['80', '443', '8086']

--- a/playbooks/roles/haproxy/defaults/main.yaml
+++ b/playbooks/roles/haproxy/defaults/main.yaml
@@ -1,6 +1,9 @@
 ---
-haproxy_image: "quay.io/opentelekomcloud/haproxy:alpine"
+haproxy_image: "quay.io/opentelekomcloud/haproxy:lts-alpine"
 haproxy_statsd_image: "quay.io/opentelekomcloud/haproxy-statsd:latest"
 container_runtime: "/usr/bin/{{ container_command }}"
 
 statsd_port: 8125
+
+# List of exposed ports
+haproxy_expose_ports: ['80', '443']

--- a/playbooks/roles/haproxy/templates/haproxy.cfg.j2
+++ b/playbooks/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,10 +1,10 @@
 global
-  uid  1000
-  gid  1000
-  log  stdout format raw local0
+  user  haproxy
+  group haproxy
+  log   stdout format raw local0
   maxconn  4000
   pidfile  /var/haproxy/run/haproxy.pid
-  stats  socket /var/haproxy/run/stats uid 1000 gid 1000 mode 0600 level admin
+  stats    socket /var/haproxy/run/stats user haproxy group haproxy mode 0600 level admin
 
   ssl-default-bind-ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
   tune.ssl.default-dh-param 4096

--- a/playbooks/roles/haproxy/templates/haproxy.service.j2
+++ b/playbooks/roles/haproxy/templates/haproxy.service.j2
@@ -9,13 +9,16 @@ ExecStartPre=-{{ container_runtime }} rm haproxy
 
 ExecStart={{ container_runtime }} run \
     --name haproxy \
-    --network host \
+{% for port in haproxy_expose_ports %}
+    -p {{ port }}:{{ port }} \
+{% endfor %}
 {% if container_command == 'podman' %}
     --log-opt=path=/dev/null \
 {% endif %}
     -v /etc/ssl/{{ inventory_hostname }}:/etc/ssl/{{ inventory_hostname }}:ro,z \
     -v /etc/haproxy:/usr/local/etc/haproxy:ro,z \
     -v haproxy_run_volume:/var/haproxy/run:rw,z \
+    --sysctl net.ipv4.ip_unprivileged_port_start=0 \
     {{ haproxy_image }}
 
 [Install]

--- a/playbooks/zuul/templates/gate-groups.yaml.j2
+++ b/playbooks/zuul/templates/gate-groups.yaml.j2
@@ -61,5 +61,3 @@ groups:
     - grafana.focal
   grafana-vm:
     - grafana.focal
-  proxy:
-    - proxy1.f32

--- a/testinfra/test_proxy.py
+++ b/testinfra/test_proxy.py
@@ -10,7 +10,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-testinfra_hosts = ['proxy.f32']
+testinfra_hosts = ['proxy1.eco.tsi-dev.otc-service.com',
+                   'proxy2.eco.tsi-dev.otc-service.com']
+
 
 def test_proxy_container_listening(host):
     sock = host.socket("tcp://0.0.0.0:443")
@@ -20,3 +22,4 @@ def test_proxy_container_listening(host):
 def test_proxy_systemd(host):
     service = host.service('haproxy')
     assert service.is_enabled
+    assert service.is_running

--- a/zuul.d/system-config-run.yaml
+++ b/zuul.d/system-config-run.yaml
@@ -278,7 +278,7 @@
       nodes:
         - name: bridge.eco.tsi-dev.otc-service.com
           label: ubuntu-focal
-        - name: proxy1.f32
+        - name: proxy1.eco.tsi-dev.otc-service.com
           label: fedora-32
     vars:
       run_playbooks:
@@ -288,3 +288,4 @@
       - tox.ini
       - playbooks/service-proxy.yaml
       - playbooks/roles/haproxy
+      - inventory/service/group_vars/proxy.yaml


### PR DESCRIPTION
Some last changes in inventory were causing proxy service failure. Jobs
are not being executed on changes only in inventory.

Change of the image  (2.3=>2.4) brings new required changes into the role, incorporate them.
