### PR TITLE
Add initial matrix config

### DIFF
--- a/inventory/service/group_vars/database-launcher.yaml
+++ b/inventory/service/group_vars/database-launcher.yaml
@@ -8,4 +8,9 @@ database_instances:
   domain2_infra_matrix:
     dba: "domain2_infra"
     name: "synapse"
+    encoding: "UTF-8"
+    lc_collate: "C"
+    lc_ctype: "C"
+    template: "template0"
+
 

--- a/inventory/service/group_vars/proxy.yaml
+++ b/inventory/service/group_vars/proxy.yaml
@@ -98,12 +98,27 @@ proxy_backends:
         address: "192.168.110.227:8086"
         opts: "check"
 
+  - name: "matrix"
+    options: []
+      #      - "http-send-name-header Host"
+    domain_names:
+      - "matrix.otc-service.com"
+    servers:
+      - name: "infra"
+        address: "192.168.170.6:443"
+        opts: "ssl verify none cookie otcinfra"
+
+
 proxy_frontends:
   - name: "influx"
     bind: "*:8086 ssl crt /etc/ssl/{{ inventory_hostname }}/haproxy"
     backend: "influx"
 
+  - name: "matrix"
+    bind: "*:8448 ssl crt /etc/ssl/{{ inventory_hostname }}/haproxy"
+    backend: "matrix"
+
 statsd_host: "192.168.14.159"
 statsd_port: "8125"
 
-haproxy_expose_ports: ['80', '443', '8086']
+haproxy_expose_ports: ['80', '443', '8086', '8448']

--- a/inventory/service/host_vars/bridge.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/bridge.eco.tsi-dev.otc-service.com.yaml
@@ -22,3 +22,5 @@ ssl_certs:
     - "graphite.apimon.eco.tsi-dev.otc-service.com"
   graphite:
     - "graphite-ca.eco.tsi-dev.otc-service.com"
+  matrix:
+    - "matrix.otc-service.com"

--- a/inventory/service/host_vars/proxy1.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/proxy1.eco.tsi-dev.otc-service.com.yaml
@@ -8,6 +8,8 @@ ssl_certs:
     - "graphite.eco.tsi-dev.otc-service.com"
     - "graphite-ca.eco.tsi-dev.otc-service.com"
     - "influx1.eco.tsi-dev.otc-service.com"
+  matrix:
+    - "matrix.otc-service.com"
 
 firewalld_extra_services_enable: ['http', 'https']
 

--- a/inventory/service/host_vars/proxy2.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/proxy2.eco.tsi-dev.otc-service.com.yaml
@@ -8,6 +8,8 @@ ssl_certs:
     - "graphite.eco.tsi-dev.otc-service.com"
     - "graphite-ca.eco.tsi-dev.otc-service.com"
     - "influx1.eco.tsi-dev.otc-service.com"
+  matrix:
+    - "matrix.otc-service.com"
 
 firewalld_extra_services_enable: ['http', 'https']
 

--- a/playbooks/roles/db_pg/tasks/db.yaml
+++ b/playbooks/roles/db_pg/tasks/db.yaml
@@ -6,3 +6,7 @@
     login_password: "{{ login.password }}"
     maintenance_db: "{{ login.database }}"
     name: "{{ instance.name }}"
+    lc_ctype: "{{ instance.lc_ctype | default(omit) }}"
+    lc_collate: "{{ instance.lc_collate | default(omit) }}"
+    encoding: "{{ instance.encoding | default(omit) }}"
+    template: "{{ instance.template | default(omit) }}"


### PR DESCRIPTION
atm matrix server is provisioned manually, but at least we can add it
under proxy config and request ssl certs properly.
