### PR TITLE
Update Grafana to 8.0.1

### DIFF
--- a/inventory/service/group_vars/grafana.yaml
+++ b/inventory/service/group_vars/grafana.yaml
@@ -4,8 +4,8 @@ default: &default_vars
   grafana_users_allow_sign_up: false
   grafana_renderer_host: "renderer"
   grafana_grafana_host: "grafana"
-  grafana_image: "quay.io/opentelekomcloud/grafana:7.5.6"
-  grafana_renderer_image: "quay.io/opentelekomcloud/grafana-image-renderer:2.1.0"
+  grafana_image: "quay.io/opentelekomcloud/grafana:8.0.1"
+  grafana_renderer_image: "quay.io/opentelekomcloud/grafana-image-renderer:3.1.0"
   grafana_users_login_hint: "OTC LDAP account"
   grafana_users_password_hint: "OTC LDAP password"
 


### PR DESCRIPTION
New grafana including hotfix is released. Same is for
grafana-image-renderer. Start using them.
Images are mirrored to regular location.
