### PR TITLE
Redeploy zuul infra

### DIFF
--- a/inventory/service/group_vars/cloud-launcher.yaml
+++ b/inventory/service/group_vars/cloud-launcher.yaml
@@ -75,6 +75,8 @@ cloud_user_groups:
     cloud: "otc-tests-admin"
   - name: "zuul_tf"
     cloud: "otc-tests-admin"
+  - name: "zuul-ci"
+    cloud: "otcinfra-domain2-admin"
   # APImon groups
   - name: "apimon"
     cloud: "otc-tests-admin"
@@ -96,6 +98,12 @@ cloud_user_group_assignments:
     users:
       - "apimon"
   # Zuul group user mapping
+  - cloud: "otcinfra-domain2-admin"
+    group: "zuul-ci"
+    users: ["zuul-ci"]
+  - cloud: "otcinfra-domain2-admin"
+    group: "zuul_nodepool"
+    users: ["zuul-ci", "zuul_nodepool"]
   - cloud: "otc-tests-admin"
     group: "zuul_functional"
     users:
@@ -120,6 +128,7 @@ cloud_role_assignments:
   - cloud: "otcinfra-domain2-admin"
     role: "te_admin"
     projects:
+      - "eu-de_zuul"
       - "eu-de_eco_infra"
       - "eu-de_database"
     groups:
@@ -127,6 +136,7 @@ cloud_role_assignments:
   - cloud: "otcinfra-domain2-admin"
     role: "server_adm"
     projects:
+      - "eu-de_zuul"
       - "eu-de_eco_infra"
       - "eu-de_database"
     groups:
@@ -162,6 +172,36 @@ cloud_role_assignments:
     groups:
       - "apimon"
   # Zuul role assignments
+  - cloud: "otcinfra-domain2-admin"
+    role: "te_admin"
+    groups: ['zuul-ci']
+    projects:
+      - "eu-de_zuul"
+      - "eu-de_zuul_pool1"
+      - "eu-de_zuul_pool2"
+      - "eu-de_zuul_pool3"
+  - cloud: "otcinfra-domain2-admin"
+    role: "server_adm"
+    groups: ['zuul-ci']
+    projects:
+      - "eu-de_zuul"
+      - "eu-de_zuul_pool1"
+      - "eu-de_zuul_pool2"
+      - "eu-de_zuul_pool3"
+  - cloud: "otcinfra-domain2-admin"
+    role: "te_admin"
+    groups: ['zuul_nodepool']
+    projects:
+      - "eu-de_zuul_pool1"
+      - "eu-de_zuul_pool2"
+      - "eu-de_zuul_pool3"
+  - cloud: "otcinfra-domain2-admin"
+    role: "server_adm"
+    groups: ['zuul_nodepool']
+    projects:
+      - "eu-de_zuul_pool1"
+      - "eu-de_zuul_pool2"
+      - "eu-de_zuul_pool3"
   - cloud: "otc-tests-admin"
     role: "te_admin"
     projects:
@@ -230,6 +270,38 @@ cloud_nets:
           - name: "apimon-infra-subnet"
             cidr: "192.168.151.0/24"
             dns_nameservers: ['100.125.4.25', '8.8.4.4']
+  - cloud: "otcci-main"
+    router: "ci"
+    nets:
+      - name: "ci-net"
+        subnets:
+          - name: "ci-subnet"
+            cidr: "192.168.21.0/24"
+            dns_nameservers: ['100.125.4.25', '8.8.4.4']
+  - cloud: "otcci-pool1"
+    router: "vpc-zuul"
+    nets:
+      - name: "zuul_net"
+        subnets:
+          - name: "subnet-zuul"
+            cidr: "192.168.101.0/24"
+            dns_nameservers: ['100.125.4.25', '8.8.4.4']
+  - cloud: "otcci-pool2"
+    router: "vpc-zuul"
+    nets:
+      - name: "zuul_net"
+        subnets:
+          - name: "subnet-zuul"
+            cidr: "192.168.102.0/24"
+            dns_nameservers: ['100.125.4.25', '8.8.4.4']
+  - cloud: "otcci-pool3"
+    router: "vpc-zuul"
+    nets:
+      - name: "zuul_net"
+        subnets:
+          - name: "subnet-zuul"
+            cidr: "192.168.103.0/24"
+            dns_nameservers: ['100.125.4.25', '8.8.4.4']
   # apimon infra
   - cloud: "otcapimon-pool2"
     router: "apimon-infra"
@@ -262,6 +334,12 @@ cloud_nat_gws:
     name: "otcinfra"
     description: "main NAT GW for the infra"
     internal_network: "apimon-infra-net"
+    spec: 1
+  - cloud: "otcci-main"
+    router: "ci"
+    name: "otcci"
+    description: "main NAT GW for the CI"
+    internal_network: "ci-net"
     spec: 1
   # apimon infra
   - cloud: "otcapimon-pool2"
@@ -308,7 +386,52 @@ cloud_peerings:
     remote_router: "dashboard-otc-vpc-router"
     remote_project: "eu-de_apimon"
     remote_cidr: "192.168.110.0/24"
-
+  # Zuul peerings
+  - cloud: "otcci-main"
+    name: "zuul-bridge"
+    local_router: "ci"
+    local_project: "eu-de_zuul"
+    local_cidr: "192.168.21.0/24"
+    remote_cloud: "otcapimon-pool1"
+    remote_router: "dashboard-otc-vpc-router"
+    remote_project: "eu-de_apimon"
+    remote_cidr: "192.168.110.0/24"
+  - cloud: "otcci-main"
+    name: "zuul-database"
+    local_router: "ci"
+    local_project: "eu-de_zuul"
+    local_cidr: "192.168.21.0/24"
+    remote_cloud: "otcinfra-domain2-database"
+    remote_router: "database_router"
+    remote_project: "eu-de_database"
+    remote_cidr: "192.168.14.0/24"
+  - cloud: "otcci-main"
+    name: "zuul-pool1"
+    local_router: "ci"
+    local_project: "eu-de_zuul"
+    local_cidr: "192.168.21.0/24"
+    remote_cloud: "otcci-pool1"
+    remote_router: "vpc-zuul"
+    remote_project: "eu-de_zuul_pool1"
+    remote_cidr: "192.168.101.0/24"
+  - cloud: "otcci-main"
+    name: "zuul-pool2"
+    local_router: "ci"
+    local_project: "eu-de_zuul"
+    local_cidr: "192.168.21.0/24"
+    remote_cloud: "otcci-pool2"
+    remote_router: "vpc-zuul"
+    remote_project: "eu-de_zuul_pool2"
+    remote_cidr: "192.168.102.0/24"
+  - cloud: "otcci-main"
+    name: "zuul-pool3"
+    local_router: "ci"
+    local_project: "eu-de_zuul"
+    local_cidr: "192.168.21.0/24"
+    remote_cloud: "otcci-pool3"
+    remote_router: "vpc-zuul"
+    remote_project: "eu-de_zuul_pool3"
+    remote_cidr: "192.168.103.0/24"
 
 common_sg: &common_sg
   name: "common_sg"
@@ -403,6 +526,26 @@ pg_sg: &pg_sg
       remote_ip_prefix: "192.168.0.0/16"
       description: "pg"
 
+zuul_sg: &zuul_sg
+  name: "default"
+  description: "Default (Zuul enabled) security group"
+  rules:
+    - protocol: "icmp"
+      port_range_min: -1
+      port_range_max: -1
+      remote_ip_prefix: "192.168.0.0/16"
+      description: "ping"
+    - protocol: "tcp"
+      port_range_min: 22
+      port_range_max: 22
+      remote_ip_prefix: "192.168.0.0/16"
+      description: "SSH"
+    - protocol: "tcp"
+      port_range_min: 19885
+      port_range_max: 19885
+      remote_ip_prefix: "192.168.0.0/16"
+      description: "Zuul logger"
+
 cloud_security_groups:
   - cloud: "otcinfra-domain2-database"
     <<: *common_sg
@@ -414,6 +557,12 @@ cloud_security_groups:
     <<: *common_sg
   - cloud: "otcinfra-domain3-infra-nl"
     <<: *graphite_sg
+  - cloud: "otcci-pool1"
+    <<: *zuul_sg
+  - cloud: "otcci-pool2"
+    <<: *zuul_sg
+  - cloud: "otcci-pool3"
+    <<: *zuul_sg
   - cloud: "otcapimon-pool1"
     <<: *pg_sg
 
@@ -458,6 +607,12 @@ cloud_load_balancers:
       vip_subnet: "infra-subnet"
       vip_address: "192.168.170.6"
       public_ip_address: "80.158.55.110"
+  - cloud: "otcci-main"
+    loadbalancer:
+      name: "elb-zuul"
+      vip_subnet: "ci-subnet"
+      vip_address: "192.168.21.20"
+      public_ip_address: "80.158.57.224"
 
 cloud_load_balancer_certificates:
   - cloud: "otc-swift"
@@ -518,3 +673,27 @@ cloud_cce:
         flavor: "s3.xlarge.4"
         az: "eu-de-03"
         os: "CentOS 7.7"
+  - cloud: "otcci-main"
+    name: "zuul"
+    flavor: "cce.s2.small"
+    router: "ci"
+    network: "ci-net"
+    network_mode: "overlay_l2"
+    nodes:
+      - name: "zuul-01"
+        flavor: "s3.2xlarge.2"
+        az: "eu-de-01"
+        os: "CentOS 7.7"
+      - name: "zuul-02"
+        flavor: "s3.2xlarge.2"
+        az: "eu-de-02"
+        os: "CentOS 7.7"
+      - name: "zuul-03"
+        flavor: "s3.2xlarge.2"
+        az: "eu-de-03"
+        os: "CentOS 7.7"
+      - name: "zuul-04"
+        flavor: "s3.2xlarge.2"
+        az: "eu-de-01"
+        os: "CentOS 7.7"
+

--- a/inventory/service/group_vars/zuul.yaml
+++ b/inventory/service/group_vars/zuul.yaml
@@ -6,9 +6,9 @@ zuul_instances:
     graphite_host: "192.168.14.241"
     statsd_host: "zuul-statsd-main"
     config_repo: "https://github.com/opentelekomcloud-infra/zuul-config.git"
-    web_domain: "https://zuul.eco.tsi-dev.otc-service.com"
+    web_domain: "zuul.otc-service.com"
     nodepool_version_tag: "4.1.0"
-    zuul_version_tag: "4.5.1"
+    zuul_version_tag: "4.6.0"
     zuul_connections:
       - name: "github"
         driver: "github"

--- a/inventory/service/groups.yaml
+++ b/inventory/service/groups.yaml
@@ -84,6 +84,7 @@ groups:
 
   # OTC environment specific variables
   otc:
+    - bridge.eco.tsi-dev.otc-service.com
     - executor1.apimon.eco.tsi-dev.otc-service.com
     - executor3.apimon.eco.tsi-dev.otc-service.com
     - executor4.apimon.eco.tsi-dev.otc-service.com

--- a/playbooks/cloud-identity.yaml
+++ b/playbooks/cloud-identity.yaml
@@ -15,19 +15,19 @@
       loop: "{{ cloud_user_groups }}"
 
     - name: Create users
-      no_log: true
+      #no_log: true
       ignore_errors: true
       openstack.cloud.identity_user:
-        cloud: "{{ item.cloud }}"
-        domain: "{{ item.domain }}"
-        name: "{{ item.name }}"
-        password: "{{ item.password }}"
-        email: "{{ item.email | default(omit) }}"
-        description: "{{ item.description | default(omit) }}"
-        update_password: "{{ item.update_password | default(omit) }}"
-        default_project: "{{ item.default_project | default(omit) }}"
-        enabled: "{{ item.enabled | default(omit) }}"
-      loop: "{{ cloud_users }}"
+        cloud: "{{ item.value.cloud }}"
+        domain: "{{ item.value.domain }}"
+        name: "{{ item.value.name }}"
+        password: "{{ item.value.password }}"
+        email: "{{ item.value.email | default(omit) }}"
+        description: "{{ item.value.description | default(omit) }}"
+        update_password: "{{ item.value.update_password | default(omit) }}"
+        default_project: "{{ item.value.default_project | default(omit) }}"
+        enabled: "{{ item.value.enabled | default(omit) }}"
+      loop: "{{ cloud_users | dict2items }}"
 
     - name: Manage user groups assignments
       cloud_user_group_assignment:

--- a/playbooks/roles/install-ansible/files/inventory_plugins/test-fixtures/results.yaml
+++ b/playbooks/roles/install-ansible/files/inventory_plugins/test-fixtures/results.yaml
@@ -10,6 +10,7 @@ results:
     - database-launcher
     - control-plane-clouds
     - k8s-controller
+    - otc
     - alerta
     - grafana
     - zuul

--- a/playbooks/roles/zuul_k8s/tasks/zuul-web.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul-web.yaml
@@ -131,10 +131,10 @@
       spec:
         tls:
           - hosts:
-              - "zuul.eco.tsi-dev.otc-service.com"
+              - "{{ zuul.web_domain }}"
             secretName: "zuul-ci-cert-main"
         rules:
-          - host: "zuul.eco.tsi-dev.otc-service.com"
+          - host: "{{ zuul.web_domain }}"
             http:
               paths:
                 - path: "/"

--- a/playbooks/roles/zuul_k8s/templates/zuul.conf.j2
+++ b/playbooks/roles/zuul_k8s/templates/zuul.conf.j2
@@ -66,8 +66,8 @@ max_starting_builds=5
 log_config=/etc/zuul/logging.conf
 listen_address=0.0.0.0
 #listen_port=9000
-status_url={{ zuul.web_domain }}
-root={{ zuul.web_domain }}
+status_url=https://{{ zuul.web_domain }}
+root=https://{{ zuul.web_domain }}
 
 {% for connection in zuul.zuul_connections -%}
 [connection "{{ connection['name'] }}"]

--- a/playbooks/templates/clouds/bridge_all_clouds.yaml.j2
+++ b/playbooks/templates/clouds/bridge_all_clouds.yaml.j2
@@ -47,6 +47,49 @@ clouds:
     identity_api_version: 3
     identity_endpoint_override: https://iam.eu-de.otc.t-systems.com/v3
 
+  # Zuul
+  otcci-main:
+    profile: otc
+    auth:
+       user_domain_name: {{ clouds.otcci_main.auth.user_domain_name }}
+       project_name: {{ clouds.otcci_main.auth.project_name }}
+       username: {{ clouds.otcci_main.auth.username }}
+       password: "{{ clouds.otcci_main.auth.password }}"
+    interface: public
+    identity_api_version: 3
+    region_name: eu-de
+  otcci-pool1:
+    profile: otc
+    auth:
+       user_domain_name: {{ clouds.otcci_pool1.auth.user_domain_name }}
+       project_name: {{ clouds.otcci_pool1.auth.project_name }}
+       username: {{ clouds.otcci_pool1.auth.username }}
+       password: "{{ clouds.otcci_pool1.auth.password }}"
+    interface: public
+    identity_api_version: 3
+    region_name: eu-de
+  otcci-pool2:
+    profile: otc
+    auth:
+       user_domain_name: {{ clouds.otcci_pool2.auth.user_domain_name }}
+       project_name: {{ clouds.otcci_pool2.auth.project_name }}
+       username: {{ clouds.otcci_pool2.auth.username }}
+       password: "{{ clouds.otcci_pool2.auth.password }}"
+    interface: public
+    identity_api_version: 3
+    region_name: eu-de
+  otcci-pool3:
+    profile: otc
+    auth:
+       user_domain_name: {{ clouds.otcci_pool3.auth.user_domain_name }}
+       project_name: {{ clouds.otcci_pool3.auth.project_name }}
+       username: {{ clouds.otcci_pool3.auth.username }}
+       password: "{{ clouds.otcci_pool3.auth.password }}"
+    interface: public
+    identity_api_version: 3
+    region_name: eu-de
+
+ # DB
   otcinfra-domain2-database:
     profile: otc
     auth:

--- a/playbooks/templates/clouds/bridge_kube_config.yaml.j2
+++ b/playbooks/templates/clouds/bridge_kube_config.yaml.j2
@@ -5,7 +5,11 @@ preferences: {}
 clusters:
   - name: otcci
     cluster: 
-      server: https://192.168.20.230:5443
+      server: {{ otcci_k8s.server }}
+      insecure-skip-tls-verify: true
+  - name: otcci-old
+    cluster: 
+      server: {{ otcci_k8s_old.server }}
       insecure-skip-tls-verify: true
   - name: otcinfra
     cluster: 
@@ -26,6 +30,10 @@ contexts:
     context:
       cluster: otcci
       user: otcci-admin
+  - name: otcci-old
+    context:
+      cluster: otcci-old
+      user: otcci-admin-old
   - name: otcinfra
     context:
       cluster: otcinfra
@@ -47,6 +55,10 @@ users:
     user:
       client-certificate-data: {{ otcci_k8s.client_certificate_data }}
       client-key-data: {{ otcci_k8s.client_key_data }}
+  - name: otcci-admin-old
+    user:
+      client-certificate-data: {{ otcci_k8s_old.client_certificate_data }}
+      client-key-data: {{ otcci_k8s_old.client_key_data }}
   - name: otcinfra-admin
     user:
       client-certificate-data: {{ otcinfra1_k8s.client_certificate_data }}

--- a/playbooks/zuul/templates/group_vars/control-plane-clouds.yaml.j2
+++ b/playbooks/zuul/templates/group_vars/control-plane-clouds.yaml.j2
@@ -45,6 +45,35 @@ clouds:
       user_domain_name: udn
       domain_name: dn
 
+  otcci_main:
+    auth:
+      username: username
+      password: pwd
+      project_name: pn
+      user_domain_name: udn
+      domain_name: dn
+  otcci_pool1:
+    auth:
+      username: username
+      password: pwd
+      project_name: pn
+      user_domain_name: udn
+      domain_name: dn
+  otcci_pool2:
+    auth:
+      username: username
+      password: pwd
+      project_name: pn
+      user_domain_name: udn
+      domain_name: dn
+  otcci_pool3:
+    auth:
+      username: username
+      password: pwd
+      project_name: pn
+      user_domain_name: udn
+      domain_name: dn
+
   otc_swift:
     auth:
       username: username
@@ -65,7 +94,8 @@ clouds:
       user_domain_name: udn
 
 cloud_users:
-  - cloud: fake
+  user1:
+    cloud: fake
     domain: fake
     name: fake
     password: fake

--- a/playbooks/zuul/templates/host_vars/bridge.eco.tsi-dev.otc-service.com.yaml.j2
+++ b/playbooks/zuul/templates/host_vars/bridge.eco.tsi-dev.otc-service.com.yaml.j2
@@ -5,6 +5,12 @@ cloud_launcher_disable_job: true
 extra_users: []
 
 otcci_k8s:
+  server: https://abc
+  client_certificate_data: fake_cert_key
+  client_key_data: fake_key_data
+
+otcci_k8s_old:
+  server: https://abc
   client_certificate_data: fake_cert_key
   client_key_data: fake_key_data
 


### PR DESCRIPTION
in order to automate Zuul infra we need to redeploy VPC, CCE. Provision
this infra now properly and on the way change to zuul.otc-service.com
domain upgrading to Zuul 4.6.0
