### PR TITLE
Switch to haproxy 2.4.1

### DIFF
--- a/inventory/service/group_vars/proxy.yaml
+++ b/inventory/service/group_vars/proxy.yaml
@@ -1,3 +1,5 @@
+haproxy_image: "quay.io/opentelekomcloud/haproxy:2.4.1-alpine"
+
 proxy_backends:
   - name: "graphite-apimon"
     options:


### PR DESCRIPTION
Sometimes we see haproxy crashes. 2.4.1 fixed some potential crashes.
Update to see whether it helps us.
