### PR TITLE
Enable carbonapi port on graphite instances

### DIFF
--- a/inventory/service/host_vars/graphite1.apimon.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/graphite1.apimon.eco.tsi-dev.otc-service.com.yaml
@@ -8,4 +8,5 @@ ssl_certs:
 
 firewalld_extra_services_enable: ['http', 'https']
 firewalld_extra_ports_enable: ['2003/tcp', '2004/tcp', '2013/tcp', '2014/tcp',
-  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8125/udp', '11211/tcp']
+  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8082/tcp', '8125/udp',
+  '11211/tcp']

--- a/inventory/service/host_vars/graphite1.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/graphite1.eco.tsi-dev.otc-service.com.yaml
@@ -7,4 +7,5 @@ ssl_certs:
 
 firewalld_extra_services_enable: ['http', 'https']
 firewalld_extra_ports_enable: ['2003/tcp', '2004/tcp', '2013/tcp', '2014/tcp',
-  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8125/udp', '11211/tcp']
+  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8082/tcp', '8125/udp',
+  '11211/tcp']

--- a/inventory/service/host_vars/graphite2.apimon.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/graphite2.apimon.eco.tsi-dev.otc-service.com.yaml
@@ -8,4 +8,5 @@ ssl_certs:
 
 firewalld_extra_services_enable: ['http', 'https']
 firewalld_extra_ports_enable: ['2003/tcp', '2004/tcp', '2013/tcp', '2014/tcp',
-  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8125/udp', '11211/tcp']
+  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8082/tcp', '8125/udp',
+  '11211/tcp']

--- a/inventory/service/host_vars/graphite3.apimon.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/graphite3.apimon.eco.tsi-dev.otc-service.com.yaml
@@ -17,4 +17,5 @@ ssl_certs:
 
 firewalld_extra_services_enable: ['http', 'https']
 firewalld_extra_ports_enable: ['2003/tcp', '2004/tcp', '2013/tcp', '2014/tcp',
-  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8125/udp', '11211/tcp']
+  '2023/tcp', '2024/tcp', '8080/tcp', '8081/tcp', '8082/tcp', '8125/udp',
+  '11211/tcp']


### PR DESCRIPTION
we have a fallback for carbonapi to be served by graphite instances, but
firewall is currently blocking required port.
