### PR TITLE
Remove host from ssl inventory

### DIFF
--- a/inventory/service/host_vars/proxy1.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/proxy1.eco.tsi-dev.otc-service.com.yaml
@@ -3,7 +3,6 @@ ssl_certs:
     - "proxy1.eco.tsi-dev.otc-service.com"
     - "dashboard.tsi-dev.otc-service.com"
     - "apimon.tsi-dev.otc-service.com"
-    - "apimon.eco.tsi-dev.otc-service.com"
     - "alerts.eco.tsi-dev.otc-service.com"
     - "graphite.eco.tsi-dev.otc-service.com"
     - "graphite-ca.eco.tsi-dev.otc-service.com"

--- a/inventory/service/host_vars/proxy2.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/proxy2.eco.tsi-dev.otc-service.com.yaml
@@ -3,7 +3,6 @@ ssl_certs:
     - "proxy2.eco.tsi-dev.otc-service.com"
     - "dashboard.tsi-dev.otc-service.com"
     - "apimon.tsi-dev.otc-service.com"
-    - "apimon.eco.tsi-dev.otc-service.com"
     - "alerts.eco.tsi-dev.otc-service.com"
     - "graphite.eco.tsi-dev.otc-service.com"
     - "graphite-ca.eco.tsi-dev.otc-service.com"


### PR DESCRIPTION
apimon.eco.tsi-dev.otc-service.com is a zone and does not really require
SSL cert. Drop it since playbook fails to get cert for it
