### PR TITLE
Fallback to apimon DS for endpoint dashboard

### DIFF
--- a/playbooks/templates/grafana/apimon/endpoint_monitor.yaml.j2
+++ b/playbooks/templates/grafana/apimon/endpoint_monitor.yaml.j2
@@ -5,7 +5,7 @@ editable: false
 panels:
 {% include '_header.yaml.j2' %}
 
-  - datasource: {{ grafana_ds | default('apimon') }}
+  - datasource: apimon
     fieldConfig:
       defaults:
         color:


### PR DESCRIPTION
endpoint monitoring dashboard on the nl@de env fails. This is caused by
something in the carbonapi, since switching back DS manually fixes the
situation. Until we figure out what is wrong - force DS for this panel
to be "apimon".
