### PR TITLE
Switch from graph to timeseries grafana panel type

### DIFF
--- a/playbooks/templates/grafana/apimon/_kpi_block_storage.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_kpi_block_storage.yaml.j2
@@ -30,7 +30,7 @@
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -65,7 +65,7 @@
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       buckets: null
       mode: time
@@ -105,7 +105,7 @@
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true

--- a/playbooks/templates/grafana/apimon/_kpi_cce.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_kpi_cce.yaml.j2
@@ -36,7 +36,7 @@
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -156,7 +156,7 @@
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true

--- a/playbooks/templates/grafana/apimon/_kpi_compute.yaml.j2
+++ b/playbooks/templates/grafana/apimon/_kpi_compute.yaml.j2
@@ -34,7 +34,7 @@
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       buckets: null
       mode: time

--- a/playbooks/templates/grafana/apimon/block_storage.yaml.j2
+++ b/playbooks/templates/grafana/apimon/block_storage.yaml.j2
@@ -29,7 +29,7 @@ panels:
       - target: groupByNode(consolidateBy(stats.timers.apimon.metric.$environment.$zone.create_volume.{_availability*,default,eu*}.passed.upper_90, 'sum'), 7, 'avg')
 
     title: Volume creation duration
-    type: graph
+    type: timeseries
     yaxes: 
       - format: ms
         show: true
@@ -56,7 +56,7 @@ panels:
     targets:
       - target: groupByNode(consolidateBy(stats.timers.apimon.metric.$environment.$zone.create_volume_snapshot.passed.upper_90, 'sum'), 7, 'avg')
     title: Volume Snapshot creation duration
-    type: graph
+    type: timeseries
     yaxes: 
       - format: ms
         show: true
@@ -83,7 +83,7 @@ panels:
     targets:
       - target: groupByNode(consolidateBy(stats.timers.apimon.metric.$environment.$zone.create_volume_backup.{default}.passed.upper_90, 'sum'), 7, 'avg')
     title: Volume Backup creation duration
-    type: graph
+    type: timeseries
     yaxes: 
       - format: ms
         show: true
@@ -110,7 +110,7 @@ panels:
     targets:
       - target: groupByNode(consolidateBy(stats.timers.apimon.metric.$environment.$zone.restore_volume_backup.passed.upper_90, 'sum'), 7, 'avg')
     title: Volume Backup Restore duration
-    type: graph
+    type: timeseries
     yaxes: 
       - format: ms
         show: true

--- a/playbooks/templates/grafana/apimon/compute.yaml.j2
+++ b/playbooks/templates/grafana/apimon/compute.yaml.j2
@@ -28,7 +28,7 @@ panels:
         target: groupByNode(stats.timers.apimon.metric.$environment.$zone.create_server.{default,eu*}.*.mean_90,
           7, 'avg')
     title: Instance Boot duration (Fedora33)
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -106,7 +106,7 @@ panels:
         target: groupByNode(stats.timers.apimon.metric.$environment.$zone.create_server_coreos.{default,eu*}.*.mean_90,
           7, 'avg')
     title: Instance Boot duration (coreos)
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -138,7 +138,7 @@ panels:
       - refId: A
         target: aliasByNode(removeEmptySeries(stats.timers.apimon.metric.$environment.$zone.metadata.*.*.*.mean), 9, 8)
     title: Metadada Server latencies
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -166,7 +166,7 @@ panels:
       - refId: A
         target: groupByNodes(stats.counters.apimon.metric.$environment.$zone.metadata.*.failed, 'sum', 7)
     title: Metadada Query failures
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true

--- a/playbooks/templates/grafana/apimon/endpoint_monitor.yaml.j2
+++ b/playbooks/templates/grafana/apimon/endpoint_monitor.yaml.j2
@@ -136,7 +136,7 @@ panels:
             openstack_api.waf: waf
             openstack_api.workspace: workspace
     transparent: true
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -176,7 +176,7 @@ panels:
       sort: 0
       value_type: individual
     transparent: true
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -229,7 +229,7 @@ panels:
       sort: 0
       value_type: individual
     transparent: true
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true

--- a/playbooks/templates/grafana/apimon/identity.yaml.j2
+++ b/playbooks/templates/grafana/apimon/identity.yaml.j2
@@ -23,7 +23,7 @@ panels:
     targets:
       - target: aliasByNode(consolidateBy(stats.timers.openstack.api.$environment.$zone.identity.POST.tokens.201.upper_90, 'max'), 5)
     title: Token creation duration
-    type: graph
+    type: timeseries
     yaxes: 
       - format: ms
         show: true

--- a/playbooks/templates/grafana/apimon/macros.j2
+++ b/playbooks/templates/grafana/apimon/macros.j2
@@ -228,7 +228,7 @@ gridPos: {x: {{ x }}, y: {{ y }}, h: {{ h }}, w: {{ w }} }
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -281,7 +281,7 @@ gridPos: {x: {{ x }}, y: {{ y }}, h: {{ h }}, w: {{ w }} }
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true

--- a/playbooks/templates/grafana/apimon/network.yaml.j2
+++ b/playbooks/templates/grafana/apimon/network.yaml.j2
@@ -27,7 +27,7 @@ panels:
       - refId: A
         target: groupByNode(stats.timers.apimon.metric.$environment.$zone.csm_lb_timings.public.*.*.mean, 8, 'avg')
     title: LoadBalancer Latency per type
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -57,7 +57,7 @@ panels:
       - refId: A
         target: groupByNode(stats.timers.apimon.metric.$environment.$zone.csm_lb_timings.public.*.*.mean, 9, 'avg')
     title: LoadBalancer Latency per AZ
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -102,7 +102,7 @@ panels:
         fill: true
         line: true
         yaxis: "left"
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -133,7 +133,7 @@ panels:
       - refId: B
         target: aliasByNode(stats.counters.apimon.metric.$environment.$zone.curl.*.failed.count, 7, 8)
     title: Domains curl Errors
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -158,7 +158,7 @@ panels:
       - refId: A
         target: groupByNodes(stats.timers.apimon.metric.$environment.$zone.dns.*.*.mean, 'avg', 7, 8)
     title: NS Lookup
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -186,7 +186,7 @@ panels:
       - refId: A
         target: aliasByNode(stats.counters.apimon.metric.$environment.$zone.dns.*.*.failed.count, 7, 8)
     title: NS Lookup Failures
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -211,7 +211,7 @@ panels:
       - refId: A
         target: groupByNodes(stats.timers.apimon.metric.$environment.$zone.ping.{vpc,peering}.*.*.mean, 'avg', 9)
     title: Internal VPC/Peering Latency
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -238,7 +238,7 @@ panels:
       - refId: A
         target: groupByNodes(stats.counters.apimon.metric.$environment.$zone.ping.{peering,vpc}.*.*.failed, 'sum', 7)
     title: Internal ping errors
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -263,7 +263,7 @@ panels:
       - refId: A
         target: groupByNodes(stats.timers.apimon.metric.$environment.$zone.ping.{natgw,snat}.*.mean, 'avg', 7)
     title: Outside NATGW/SNAT ping Latency
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -290,7 +290,7 @@ panels:
       - refId: A
         target: groupByNodes(stats.counters.apimon.metric.$environment.$zone.ping.{natgw,snat}.*.failed, 'sum', 7)
     title: Outside ping errors
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true

--- a/playbooks/templates/grafana/apimon/test_results.yaml.j2
+++ b/playbooks/templates/grafana/apimon/test_results.yaml.j2
@@ -34,7 +34,7 @@ panels:
         value: 0
         yaxis: left
     title: No response count
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -78,7 +78,7 @@ panels:
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -150,7 +150,7 @@ panels:
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true
@@ -228,7 +228,7 @@ panels:
       shared: true
       sort: 0
       value_type: individual
-    type: graph
+    type: timeseries
     xaxis:
       mode: time
       show: true


### PR DESCRIPTION
in Grafana 8 panel type "graph" is declared deprecated. Switch to
timeseries. It requires however adding some further properties
