### PR TITLE
Add tags into zuul playbooks/role

### DIFF
--- a/playbooks/roles/zuul_k8s/tasks/main.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/main.yaml
@@ -1,17 +1,23 @@
 - include_role:
     name: "x509_cert"
     tasks_from: cert.yaml
+    apply:
+      tags: ["config"]
   vars:
-    x509_common_name: "{{ item }}"
+    x509_common_name: "{{ zj_cert_item }}"
+  tags: ["config"]
   loop:
     - "zuul-{{ instance }}-zk-client"
     - "zuul-{{ instance }}-gearman-server"
     - "zuul-{{ instance }}-gearman-client"
+  loop_control:
+    loop_var: zj_cert_item
 
 - name: Create zuul-config dir
   file:
     path: "{{ zuul_config_dir }}"
     state: directory
+  tags: ["config"]
 
 - name: Update from master
   #when: "{{ zuul.pipeline|default('') in ['periodic', 'periodic-hourly'] }}"
@@ -20,6 +26,7 @@
     repo: "{{ zuul.config_repo }}"
     dest: "{{ zuul_config_dir }}/{{ instance }}"
     force: yes
+  tags: ["config"]
 
 - name: Create Zull Namespace
   community.kubernetes.k8s:
@@ -66,7 +73,11 @@
         cacert.pem: "{{ lookup('file', x509_certs[('zuul-' + instance + '-zk-client')]['ca']) | string | b64encode }}"
         cert.pem: "{{ lookup('file', x509_certs[('zuul-' + instance + '-zk-client')]['cert']) | string | b64encode }}"
         key.pem: "{{ lookup('file', x509_certs[('zuul-' + instance + '-zk-client')]['key']) | string | b64encode }}"
+  tags: ["config"]
 
 - include_tasks: statsd.yaml
+  tags: ["config"]
 - include_tasks: nodepool.yaml
+  tags: ["config"]
 - include_tasks: zuul.yaml
+  tags: ["config"]

--- a/playbooks/roles/zuul_k8s/tasks/nodepool.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/nodepool.yaml
@@ -16,6 +16,7 @@
           app.kubernetes.io/managed-by: "system-config"
       data:
         nodepool.yaml: "{{ lookup('file', ([zuul_config_dir, instance, 'nodepool', 'nodepool.yaml'] | join('/')) ) }}"
+  tags: ["config"]
 
 - name: Create Nodepool Clouds config
   community.kubernetes.k8s:
@@ -34,6 +35,7 @@
           app.kubernetes.io/managed-by: "system-config"
       data:
         clouds.yaml: "{{ lookup('template', 'templates/clouds/nodepool_clouds.yaml.j2') | string | b64encode }}"
+  tags: ["config"]
 
 - name: Create nodepool-launcher deployment
   community.kubernetes.k8s:

--- a/playbooks/roles/zuul_k8s/tasks/statsd.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/statsd.yaml
@@ -16,6 +16,7 @@
           app.kubernetes.io/managed-by: "system-config"
       data:
         config.js: "{{ lookup('template', 'statsd-config.js.j2') }}"
+  tags: ["config"]
 
 - name: Create Statsd Service
   community.kubernetes.k8s:

--- a/playbooks/roles/zuul_k8s/tasks/zuul-scheduler.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul-scheduler.yaml
@@ -16,6 +16,7 @@
       data:
         main.yaml: "{{ lookup('file', ([zuul_config_dir, instance, 'zuul', 'main.yaml'] | join('/')) ) }}"
   register: zuul_scheduler_tenant_config
+  tags: ["config"]
 
 - name: Create Zuul Scheduler Service
   community.kubernetes.k8s:

--- a/playbooks/roles/zuul_k8s/tasks/zuul.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul.yaml
@@ -16,6 +16,7 @@
       data:
         zuul.conf: "{{ lookup('template', 'zuul.conf.j2') }}"
         logging.conf: "{{ lookup('file', 'logging.conf') }}"
+  tags: ["config"]
 
 - name: Create Zuul SSL Secrets
   community.kubernetes.k8s:
@@ -37,6 +38,7 @@
         gearman-client.pem: "{{ lookup('file', x509_certs[('zuul-' + instance + '-gearman-client')]['cert']) | string | b64encode }}"
         gearman-client.key: "{{ lookup('file', x509_certs[('zuul-' + instance + '-gearman-client')]['key']) | string | b64encode }}"
         github.key: "{{ zuul.github_app_key | string | b64encode }}"
+  tags: ["config"]
 
 - name: Create Zuul Scheduler Secrets
   community.kubernetes.k8s:
@@ -57,6 +59,7 @@
         gearman-ca.pem: "{{ lookup('file', x509_certs[('zuul-' + instance + '-gearman-server')]['ca']) | string | b64encode }}"
         gearman-server.pem: "{{ lookup('file', x509_certs[('zuul-' + instance + '-gearman-server')]['cert']) | string | b64encode }}"
         gearman-server.key: "{{ lookup('file', x509_certs[('zuul-' + instance + '-gearman-server')]['key']) | string | b64encode }}"
+  tags: ["config"]
 
 - name: Create Zuul Executor Key Secret
   community.kubernetes.k8s:
@@ -75,8 +78,13 @@
           app.kubernetes.io/managed-by: "system-config"
       data:
         nodepool_id_rsa: "{{ zuul.zuul_ssh_private_key_contents | string | b64encode }}"
+  tags: ["config"]
 
 - include_tasks: zuul-merger.yaml
+  tags: ["config"]
 - include_tasks: zuul-scheduler.yaml
+  tags: ["config"]
 - include_tasks: zuul-web.yaml
+  tags: ["config"]
 - include_tasks: zuul-executor.yaml
+  tags: ["config"]

--- a/playbooks/service-zuul-k8s.yaml
+++ b/playbooks/service-zuul-k8s.yaml
@@ -4,9 +4,10 @@
   tasks:
     - set_fact:
         x509_certs: {}
+      tags: ["config"]
 
     - include_role:
-        name: zuul_k8s
+        name: "zuul_k8s"
       vars:
         zuul: "{{ zuul_instances[item.zuul_instance] | combine(zuul_instances_secrets[item.zuul_instance], recursive=True) }}"
         instance: "{{ item.instance }}"
@@ -16,4 +17,5 @@
         # In k8 we can not mount secret and cm under same path
         apimon_secure_file_location: "/etc/apimon_secure/apimon-secure.yaml"
         executor_secure_file_location: "/etc/apimon_secure/apimon-executor-secure.yaml"
+      tags: ["config"]
       loop: "{{ zuul_k8s_instances | list }}"


### PR DESCRIPTION
In order to be able to only refresh zuul confguration add "config" tag
to multiple tasks of the zuul deployment. invoking it with
`ansible-playbook playbooks/service-zuul-k8s.yaml --tags config` only
updates configs.
