### PR TITLE
reload apprantly does not rescue from haproxy down backends

### DIFF
--- a/playbooks/roles/haproxy_monitor/tasks/main.yaml
+++ b/playbooks/roles/haproxy_monitor/tasks/main.yaml
@@ -15,7 +15,7 @@
         loop_var: "frontend"
 
   rescue:
-    - name: Reload Haproxy
+    - name: Restart Haproxy
       ansible.builtin.service:
         name: "haproxy"
-        state: "reloaded"
+        state: "restarted"


### PR DESCRIPTION
from logs we see reload happens, but it is not able to recover when all
backends are down.
