### PR TITLE
changed curl parameter to -m

### DIFF
--- a/playbooks/roles/carbonapi/templates/carbonapi-healthcheck.sh.j2
+++ b/playbooks/roles/carbonapi/templates/carbonapi-healthcheck.sh.j2
@@ -4,7 +4,7 @@
 count=0
 
 for i in $(seq 3);do
-  curl -s http://localhost:8082/lb_check --connect-timeout 2 > /dev/null
+  curl -s http://localhost:8082/lb_check -m 2 > /dev/null
   if [ $? -ne 0 ];then
     ((count=count+1))
   fi


### PR DESCRIPTION
Changed parameter for curl to use -m , maximum time for whole operation to take before exit.

With --connect-timeout there are cases where tcp port is open, but application does not respond and curl hangs.
