### PR TITLE
rename sysconfig logrotate conf file

### DIFF
--- a/playbooks/roles/base/server/tasks/main.yaml
+++ b/playbooks/roles/base/server/tasks/main.yaml
@@ -33,7 +33,7 @@
 
 - name: Deploy SystemConfig logrotate config
   ansible.builtin.template:
-    dest: "/etc/logrotate.d/system-config"
+    dest: "/etc/logrotate.d/1system-config"
     src: "logrotate.j2"
   notify: Restart logrotate
 


### PR DESCRIPTION
Due to the fact, that in logrotate order of config files matters -
ensure our file is the first one.
