### PR TITLE
Adapt SSL setting of haproxy

### DIFF
--- a/playbooks/roles/haproxy/templates/haproxy.cfg.j2
+++ b/playbooks/roles/haproxy/templates/haproxy.cfg.j2
@@ -9,6 +9,13 @@ global
   ssl-default-bind-ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
   tune.ssl.default-dh-param 4096
 
+  # modern configuration
+  ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-bind-options prefer-client-ciphers no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets
+
+  ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-server-options no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets
+
 defaults
   log-format  "%ci:%cp [%t] %ft [%bi]:%bp %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
   log  global
@@ -32,7 +39,7 @@ defaults
 frontend web
   mode http
   bind *:80
-  bind *:443 ssl crt /etc/ssl/{{ inventory_hostname }}/haproxy
+  bind *:443 ssl crt /etc/ssl/{{ inventory_hostname }}/haproxy alpn h2,http/1.1
 
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }


### PR DESCRIPTION
Use
https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=modern&openssl=1.1.1d&guideline=5.6
to configure our haproxy in the best secure way.
