### PR TITLE
logrotate update

### DIFF
--- a/playbooks/roles/base/server/tasks/main.yaml
+++ b/playbooks/roles/base/server/tasks/main.yaml
@@ -37,6 +37,12 @@
     src: "logrotate.j2"
   notify: Restart logrotate
 
+- name: Ensure logrotate.timer is running
+  ansible.builtin.service:
+    name: logrotate.timer
+    enabled: yes
+    state: started
+
 - name: Ensure rsyslog is running
   ansible.builtin.service:
     name: rsyslog

--- a/playbooks/roles/base/server/tasks/main.yaml
+++ b/playbooks/roles/base/server/tasks/main.yaml
@@ -42,6 +42,7 @@
     name: logrotate.timer
     enabled: yes
     state: started
+  ignore_errors: true
 
 - name: Ensure rsyslog is running
   ansible.builtin.service:


### PR DESCRIPTION
- ensures logrotate.timer is running
- adding ignore_errors for distros which do not use timer service for logrotate like Centos 8
