### PR TITLE
Update propose jobs

### DIFF
--- a/playbooks/library/update_tag.py
+++ b/playbooks/library/update_tag.py
@@ -69,7 +69,8 @@ class ProposeModule():
             return f"{key.split('.')[-1]}-{new_value[-1]}"
 
     def commit_changes(
-        self, repo_location, branch_name: str, path: str, key: str,
+        self, repo_location, branch_name: str, path: str,
+        key: str, value: str,
         token: str
     ):
         """
@@ -96,7 +97,8 @@ class ProposeModule():
                     'title': f"[Automatic]: Update {key}",
                     'head': branch_name,
                     'base': 'main',
-                    'maintainer_can_modify': True
+                    'maintainer_can_modify': True,
+                    'body': f"Update {key} to {value}"
                 }
             )
             if response.status_code >= 400:
@@ -137,8 +139,9 @@ class ProposeModule():
         if all(v is not None for v in (username, email)):
             proposal_branch = self.get_proposal_branch_name(key, value)
             repo = self.get_repo_and_set_config(username, email)
-            self.commit_changes(repo_location, proposal_branch, path, key,
-                                token)
+            self.commit_changes(
+                repo_location, proposal_branch, path,
+                key, value, token)
 
         self.ansible.exit_json(changed=True)
 

--- a/playbooks/propose-update.yaml
+++ b/playbooks/propose-update.yaml
@@ -16,8 +16,8 @@
           update_tag:
             repo_location: "{{ tmp_dir.path }}"
             path: "inventory/service/group_vars/all.yaml"
-            key: "{{ key }}"
-            value: "{{ value }}"
+            key: "{{ propose_key }}"
+            value: "{{ propose_value }}"
             email: "otcbot@eco.tsi-dev.otc-service.com"
             username: "{{ github_user }}"
             token: "{{ github_token }}"

--- a/playbooks/zuul/run-production-playbook.yaml
+++ b/playbooks/zuul/run-production-playbook.yaml
@@ -31,13 +31,17 @@
     - name: Run the production playbook and capture logs
       block:
 
+      - name: Construct execution command
+        set_fact:
+          ansible_command: "ansible-playbook -v -f {{ infra_prod_ansible_forks }} /home/zuul/src/github.com/opentelekomcloud-infra/system-config/playbooks/{{ playbook_name }} -e '{{ ((extra_job_vars | default({})) | to_json }}'"
+
       - name: Log a playbook start header
         become: yes
-        shell: 'echo "Running {{ ansible_date_time.iso8601 }}: ansible-playbook -v -f {{ infra_prod_ansible_forks }} /home/zuul/src/github.com/opentelekomcloud-infra/system-config/playbooks/{{ playbook_name }}" > /var/log/ansible/{{ playbook_name }}.log'
+        shell: 'echo "Running {{ ansible_date_time.iso8601 }}: {{ ansible_command }}" > /var/log/ansible/{{ playbook_name }}.log'
 
       - name: Run specified playbook on bridge and redirect output
         become: yes
-        shell: 'ansible-playbook -vvv -f {{ infra_prod_ansible_forks }} /home/zuul/src/github.com/opentelekomcloud-infra/system-config/playbooks/{{ playbook_name }} >> /var/log/ansible/{{ playbook_name }}.log'
+        shell: "{{ ansible_command } >> /var/log/ansible/{{ playbook_name }}.log}"
 
       always:
 

--- a/zuul.d/infra-prod.yaml
+++ b/zuul.d/infra-prod.yaml
@@ -353,6 +353,9 @@
     description: Propose inventory change
     vars:
       playbook_name: propose-update.yaml
+      extra_job_vars:
+        propose_key: "{{ propose_key }}"
+        propose_value: "{{ value }}"
     dependencies:
       - name: infra-prod-install-ansible
         soft: true
@@ -364,13 +367,11 @@
     parent: infra-prod-propose-update
     description: Propose new Octavia-proxy image
     vars:
-      playbook_name: propose-update.yaml
-      key: "octavia_proxy_image_stable"
+      propose_key: "octavia_proxy_image_stable"
 
 - job:
     name: infra-prod-propose-octavia-proxy-image-latest
     parent: infra-prod-propose-update
     description: Propose new Octavia-proxy image
     vars:
-      playbook_name: propose-update.yaml
-      key: "octavia_proxy_image_latest"
+      propose_key: "octavia_proxy_image_latest"


### PR DESCRIPTION
When zuul invokes ansible we loose additional variables. Implement
support for extra_job_vars and start using it in the propose jobs.
