### PR TITLE
disable nginx caching in docsportal

### DIFF
--- a/playbooks/templates/docs_hosting/nginx-public.conf.j2
+++ b/playbooks/templates/docs_hosting/nginx-public.conf.j2
@@ -47,7 +47,7 @@ server {
       set $index_uri '/$1';
       break;
     }
-    if ($request_uri ~* '^/_static') {
+    if ($request_uri ~* '(^/_static)|(^/_images)') {
       # statics from docportal
       set $index_uri $request_uri;
       break;


### PR DESCRIPTION
disable caching and route _images of the root properly