### PR TITLE
Remove readding bridge key.

### DIFF
--- a/playbooks/zuul/run-production-playbook.yaml
+++ b/playbooks/zuul/run-production-playbook.yaml
@@ -1,3 +1,5 @@
+# Re-adding host to inventory is required since Zuul runs with ephemeral
+# inventory and do not really contain bridge in this playbook inventory.
 - hosts: localhost
   tasks:
     - name: Add bridge to inventory
@@ -7,13 +9,6 @@
         ansible_user: zuul
         ansible_host: bridge.eco.tsi-dev.otc-service.com
         ansible_port: 22
-
-- hosts: localhost
-  tasks:
-    - name: Add bridge hostkey to known hosts
-      known_hosts:
-        name: bridge.eco.tsi-dev.otc-service.com
-        key: "bridge.eco.tsi-dev.otc-service.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCihP3c2JSZG6aFFVruAh3TXlygaoVfon3aUwmpmBVwLbmlpHmuIMfG3dpdFfuEVjwRB1FNp3w510gbDZl+K/E/6trnxkZ7iNkVCL1VZoFrpFQU065QaP3uIrwGWdNeatTrI14YlM4CFIyrdsUithy28RaoKDBFOV4DTLuNZvGvogc7fR4nkTDitzeyEkGugD7v9ZNQiW7tyPiUv1nP911vTSA+R1cJkXlXx1FAxC6y1qXJuH4nKoCmPrYBGanljiUvGHt4YLCF0evYnMipuO0uSMvZG1qGjP1GtSOac1BhKnjTUNaXIYPr8WFB7N57VLDHgfa5s/zLS5P6BdC7FogPuFs9+6k9n4uko9ugYx4cXKObYzbrvvWMwEG5dIphde+Tv9uwpY66cKDpaFYapKN3FpGE3Q9wi43JSjXeySSJJIgafIskTpkmBwgEAM8L0NOqIAAjW8Q+gdxMneD3C5QlAXsb5dLPPuVylVObg5VDi4+u278ndko+DfCbGDw/rYU="
 
 - hosts: bridge.eco.tsi-dev.otc-service.com
   tasks:


### PR DESCRIPTION
It was already done in the base-jobs playbook. Adding host is still
required.
