### PR TITLE
Replace executor2 host

### DIFF
--- a/inventory/base/hosts.yaml
+++ b/inventory/base/hosts.yaml
@@ -14,7 +14,7 @@ all:
       ansible_host: 192.168.110.225
       ansible_user: automation
     executor2.apimon.eco.tsi-dev.otc-service.com:
-      ansible_host: 192.168.2.55
+      ansible_host: 192.168.2.60
       ansible_user: automation
     executor3.apimon.eco.tsi-dev.otc-service.com:
       ansible_host: 192.168.110.145


### PR DESCRIPTION
Deploy new FCOS to replace existing executor2. It is deployed with the
ignition file providing desired disk setup.
