### PR TITLE
become root for dns management

### DIFF
--- a/playbooks/acme-certs.yaml
+++ b/playbooks/acme-certs.yaml
@@ -4,6 +4,7 @@
     - acme_request_certs
 
 - hosts: bridge.eco.tsi-dev.otc-service.com
+  become: true
   roles:
     - acme_install_txt_records
 
@@ -13,5 +14,6 @@
     - acme_create_certs
 
 - hosts: bridge.eco.tsi-dev.otc-service.com
+  become: true
   roles:
     - acme_drop_txt_records


### PR DESCRIPTION
Since we provision clouds creds to root we also need to become root for
using those creds. Until we learn playbook to get vals from vault - just
use root.
