### PR TITLE
Fix bootstrap-bridge job

### DIFF
--- a/zuul.d/infra-prod.yaml
+++ b/zuul.d/infra-prod.yaml
@@ -39,7 +39,7 @@
         against itself; it includes things not strictly needed to make
         the host able to deploy system-config.
     vars:
-      playbook_name: install-ansible.yaml
+      playbook_name: bootstrap-bridge.yaml
     required-projects:
       - name: github.com/opentelekomcloud/ansible-collection-apimon
         override-checkout: main

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -14,7 +14,10 @@
         - system-config-run-apimon-epmon
         - system-config-run-apimon-scheduler
         - system-config-run-apimon-executor
-        - system-config-run-graphite
+        - system-config-run-graphite: &system-config-run-graphite
+            dependencies:
+              - name: system-config-run-memcached
+                soft: true
         - system-config-run-memcached
         - system-config-run-alerta
         - system-config-run-grafana
@@ -34,7 +37,7 @@
         - system-config-run-apimon-epmon
         - system-config-run-apimon-scheduler
         - system-config-run-apimon-executor
-        - system-config-run-graphite
+        - system-config-run-graphite: *system-config-run-graphite
         - system-config-run-memcached
         - system-config-run-alerta
         - system-config-run-grafana

--- a/zuul.d/system-config-run.yaml
+++ b/zuul.d/system-config-run.yaml
@@ -70,7 +70,7 @@
       run_playbooks:
         - playbooks/service-statsd.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/roles/statsd
       - testinfra/test_statsd.py
 
@@ -87,7 +87,7 @@
       run_playbooks:
         - playbooks/x509-certs.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/x509-certs.yaml
       - playbooks/roles/x509_cert
 
@@ -109,7 +109,7 @@
       run_playbooks:
         - playbooks/service-apimon-epmon.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/templates/apimon
       - playbooks/zuul/templates/group_vars/apimon
       - playbooks/zuul/templates/host_vars/epmon
@@ -134,7 +134,7 @@
       run_playbooks:
         - playbooks/service-apimon-scheduler.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/templates/apimon
       - playbooks/zuul/templates/group_vars/apimon
       - playbooks/service-apimon-scheduler.yaml
@@ -158,7 +158,7 @@
       run_playbooks:
         - playbooks/service-apimon-executor.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/templates/apimon
       - playbooks/zuul/templates/group_vars/apimon
       - playbooks/service-apimon-executor.yaml
@@ -183,7 +183,7 @@
         - playbooks/acme-certs.yaml
         - playbooks/service-graphite.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/service-graphite.yaml
       - playbooks/roles/graphite
       - playbooks/roles/graphite_web
@@ -206,7 +206,7 @@
       run_playbooks:
         - playbooks/service-memcached.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/service-memcached.yaml
       - playbooks/roles/memcached
       - testinfra/test_memcached.py
@@ -226,7 +226,7 @@
       run_playbooks:
         - playbooks/service-alerta.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/service-alerta.yaml
       - playbooks/roles/alerta/
       - testinfra/test_alerta.py
@@ -246,7 +246,7 @@
       run_playbooks:
         - playbooks/service-grafana.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/service-grafana.yaml
       - playbooks/roles/grafana/
       - testinfra/test_grafana.py
@@ -266,7 +266,7 @@
       run_playbooks:
         - playbooks/acme-certs.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/acme-ssl.yaml
       - playbooks/roles/acme_create_certs
       - playbooks/roles/acme_request_certs
@@ -289,7 +289,7 @@
         - playbooks/acme-certs.yaml
         - playbooks/service-proxy.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/service-proxy.yaml
       - playbooks/roles/haproxy
       - inventory/service/group_vars/proxy.yaml
@@ -311,7 +311,7 @@
         - playbooks/acme-certs.yaml
         - playbooks/service-vault.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/service-vault.yaml
       - playbooks/roles/hashivault
       - inventory/service/groups.yaml
@@ -335,7 +335,7 @@
         - playbooks/x509-certs.yaml
         - playbooks/service-zookeeper.yaml
     files:
-      - tox.ini
+      - playbooks/bootstrap-bridge.yaml
       - playbooks/service-zookeeper.yaml
       - playbooks/roles/zookeeper
       - inventory/service/groups.yaml


### PR DESCRIPTION
last commit renamed install-ansible job/playbook to boostrap-bridge, but
the job still tried to use old playbook name. Fix this and add playbook
to the system-run job filters.
