### PR TITLE
Change zk vault token to be read from projected volume

### DIFF
--- a/playbooks/roles/zookeeper/templates/k8s_config.yaml.j2
+++ b/playbooks/roles/zookeeper/templates/k8s_config.yaml.j2
@@ -131,6 +131,7 @@ data:
             mount_path = "{{ zookeeper.vault_k8_auth_mount_path }}"
             config = {
                 role = "{{ zookeeper.vault_role_name }}"
+                paht = "/run/secrets/tokens/vault-token""
             }
         }
         sink "file" {

--- a/playbooks/roles/zookeeper/templates/statefulset.yaml.j2
+++ b/playbooks/roles/zookeeper/templates/statefulset.yaml.j2
@@ -46,6 +46,9 @@ spec:
               name: "vault-agent-config"
             - mountPath: "/tls"
               name: "cert-data"
+            - mountPath: /var/run/secrets/tokens
+              name: k8-tokens
+
       containers:
         - args:
             - agent
@@ -62,6 +65,9 @@ spec:
               name: "vault-agent-config"
             - mountPath: "/tls"
               name: "cert-data"
+            - mountPath: /var/run/secrets/tokens
+              name: k8-tokens
+
         - name: "zookeeper"
           securityContext:
             fsGroup: 1000
@@ -148,6 +154,13 @@ spec:
             defaultMode: 0555
         - emptyDir: {}
           name: cert-data
+        - name: k8-tokens
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 7200
+                path: vault-token
   volumeClaimTemplates:
     - metadata:
         name: datadir


### PR DESCRIPTION
in order to rely on more short-living tokens use serviceAccountToken
volume projection
(https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection)
