### PR TITLE
Add zuul-client k8 deployment

### DIFF
--- a/playbooks/roles/zuul_k8s/tasks/zuul-client.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul-client.yaml
@@ -1,0 +1,139 @@
+- name: Create Zuul Client deployment
+  community.kubernetes.k8s:
+    context: "{{ context }}"
+    state: "present"
+    namespace: "{{ namespace }}"
+    name: "zuul-client-{{ instance }}"
+    api_version: "v1"
+    kind: "Deployment"
+    apply: "yes"
+    definition:
+      metadata:
+        labels:
+          app.kubernetes.io/app: "zuul"
+          app.kubernetes.io/component: "zuul-client"
+          app.kubernetes.io/instance: "{{ instance }}"
+          app.kubernetes.io/managed-by: "system-config"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/app: "zuul"
+            app.kubernetes.io/component: "zuul-client"
+            app.kubernetes.io/instance: "{{ instance }}"
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/app: "zuul"
+              app.kubernetes.io/component: "zuul-client"
+              app.kubernetes.io/instance: "{{ instance }}"
+            annotations:
+              vaultConfVersion: "{{ zuul_vault_cm_version | default(omit) }}"
+              zkClientCertValidity: "{{ zk_client_cert_info.not_after }}"
+          spec:
+            serviceAccountName: "{{ zuul_service_account_name }}"
+            initContainers:
+              - name: "vault-agent"
+                command:
+                  - "sh"
+                  - "-c"
+                  - "vault agent -config=/etc/vault/vault-agent-config-zuul-web.hcl -exit-after-auth=true && mkdir -p /etc/zuul && cp -ruvT /secrets/zuul /etc/zuul"
+                env:
+                  - name: "VAULT_ADDR"
+                    value: "{{ ansible_hashi_vault_addr }}"
+                image: "{{ zuul.vault_image }}"
+                volumeMounts:
+                  - mountPath: "/etc/vault"
+                    name: "vault-agent-config"
+                  - mountPath: "/secrets"
+                    name: "secrets"
+
+            containers:
+              # Zuul-client is a regular zuul-web image doing nothing.
+              # We use it only to have completely independent pod serving as
+              # zuul client for i.e. maintenance.
+              - name: "zuul-client"
+                image: "quay.io/opentelekomcloud/zuul-web:{{ zuul.zuul_version_tag }}"
+                command:
+                  - "sh"
+                  - "-c"
+                  - "while :; do sleep 60; done"
+                resources:
+                  limits:
+                    cpu: "50m"
+                    memory: "200Mi"
+                  requests:
+                    cpu: "20m"
+                    memory: "100Mi"
+                volumeMounts:
+                  - name: "certs"
+                    readOnly: true
+                    mountPath: "/etc/zuul/ssl"
+                  - name: "cert-data"
+                    mountPath: "/tls"
+                    readOnly: true
+                  - name: "zk-certs"
+                    readOnly: true
+                    mountPath: "/etc/zuul/zk"
+                  - mountPath: "/etc/zuul"
+                    name: "zuul-config"
+
+              # Vault agent produces files as vault user. We need to ensure
+              # those have correct ownership and privs, therefore permanently
+              # try to copy/fix what vault produces
+              - name: "conf-priv-fixer"
+                image: "busybox:1.34.1-musl"
+                command:
+                  - "sh"
+                  - "-c"
+                  - "while :; do cp -v /secrets/tls/* /tls/; cp -ruvT /secrets/zuul /etc/zuul; chown -R 10001:10001 /etc/zuul /tls; sleep 60; done"
+                volumeMounts:
+                  - name: "cert-data"
+                    mountPath: "/tls"
+                  - name: "zuul-config"
+                    mountPath: "/etc/zuul"
+                  - name: "secrets"
+                    mountPath: "/secrets"
+
+              - name: "vault-agent-sidecar"
+                command:
+                  - "sh"
+                  - "-c"
+                  - "vault agent -config=/etc/vault/vault-agent-config-zuul-web.hcl"
+                env:
+                  - name: "VAULT_ADDR"
+                    value: "{{ ansible_hashi_vault_addr }}"
+                image: "{{ zuul.vault_image }}"
+                volumeMounts:
+                  - mountPath: "/etc/vault"
+                    name: "vault-agent-config"
+                  - mountPath: "/secrets"
+                    name: "secrets"
+
+            volumes:
+              - name: "config"
+                configMap:
+                  name: "zuul-config-{{ instance }}"
+              - name: "certs"
+                secret:
+                  secretName: "zuul-{{ instance }}"
+              - name: "vault-agent-config"
+                configMap:
+                  name: "vault-agent-config-{{ instance }}"
+              - name: "zk-certs"
+                secret:
+                  secretName: "zuul-zk-certs-{{ instance }}"
+              - name: "cert-data"
+                emptyDir: {}
+              - name: "zuul-config"
+                emptyDir: {}
+              - name: "secrets"
+                emptyDir: {}
+
+        strategy:
+          type: "RollingUpdate"
+          rollingUpdate:
+            maxUnavailable: 25%
+            maxSurge: 25%
+        revisionHistoryLimit: 10
+        progressDeadlineSeconds: 600

--- a/playbooks/roles/zuul_k8s/tasks/zuul.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul.yaml
@@ -50,3 +50,5 @@
   tags: ["config"]
 - include_tasks: zuul-executor.yaml
   tags: ["config"]
+- include_tasks: zuul-client.yaml
+  tags: ["config"]


### PR DESCRIPTION
We might need to have a standalone zuul client to do some maintenance
(i.e. it is required to clean ZK state while doing update to 4.11 while
zuul itself is down). Since we are moving slowly to having zk in the k8
itself we can only reasonably have zuul client in the same k8 (for case
when zk is not accessible from outside).
