### PR TITLE
Add grafana-datasources job

### DIFF
--- a/inventory/service/groups.yaml
+++ b/inventory/service/groups.yaml
@@ -141,6 +141,9 @@ groups:
     - web3.eco.tsi-dev.otc-service.com
     - bridge.eco.tsi-dev.otc-service.com
 
+  grafana-controller:
+    - bridge.eco.tsi-dev.otc-service.com
+
   proxy:
     - proxy1.eco.tsi-dev.otc-service.com
     - proxy2.eco.tsi-dev.otc-service.com

--- a/playbooks/grafana-datasources.yaml
+++ b/playbooks/grafana-datasources.yaml
@@ -1,0 +1,10 @@
+# Manage grafana datasources
+- hosts: "grafana-controller:!disabled"
+  tasks:
+    - include_role:
+        name: "grafana"
+        tasks_from: "import_ds.yaml"
+      vars:
+        grafana_datasource_content: "{{ item.value }}"
+        grafana_datasource_name: "{{ item.key }}"
+      loop: "{{ grafana_datasources | dict2items }}"

--- a/playbooks/roles/grafana/tasks/import_ds.yaml
+++ b/playbooks/roles/grafana/tasks/import_ds.yaml
@@ -1,0 +1,30 @@
+- name: "Create DataSource {{ grafana_datasource_name }}"
+  community.grafana.grafana_datasource:
+    state: "present"
+    name: "{{ grafana_datasource_name }}"
+
+    grafana_url: "{{ grafana_datasource_content.grafana_url }}"
+    grafana_api_key: "{{ grafana_api_key }}"
+
+    ds_type: "{{ grafana_datasource_content.ds_type }}"
+    ds_url: "{{ grafana_datasource_content.ds_url }}"
+    is_default: "{{ grafana_datasource_content.is_default | default(omit) }}"
+
+    tls_ca_cert: "{{ grafana_datasource_content.tls_ca_cert | default(omit) }}"
+    tls_client_cert: "{{ grafana_datasource_content.tls_client_cert | default(omit) }}"
+    tls_client_key: "{{ grafana_datasource_content.tls_client_key | default(omit) }}"
+    tls_skip_verify: "{{ grafana_datasource_content.tls_skip_verify | default(omit) }}"
+
+    database: "{{ grafana_datasource_content.database | default(omit) }}"
+    user: "{{ grafana_datasource_content.user | default(omit) }}"
+    sslmode: "{{ grafana_datasource_content.sslmode | default(omit) }}"
+
+    basic_auth_user: "{{ grafana_datasource_content.basic_auth_user | default(omit) }}"
+    basic_auth_password: "{{ grafana_datasource_content.basic_auth_password | default(omit) }}"
+    client_cert: "{{ grafana_datasource_content.client_cert | default(omit) }}"
+    client_key: "{{ grafana_datasource_content.client_key | default(omit) }}"
+
+    access: "{{ grafana_datasource_content.access | default(omit) }}"
+    additional_json_data: "{{ grafana_datasource_content.additional_json_data | default(omit) }}"
+    additional_secure_json_data: "{{ grafana_datasource_content.additional_secure_json_data | default(omit) }}"
+    enforce_secure_data: "{{ grafana_datasource_content.enforce_secure_data | default(omit) }}"

--- a/playbooks/roles/install-ansible/files/inventory_plugins/test-fixtures/results.yaml
+++ b/playbooks/roles/install-ansible/files/inventory_plugins/test-fixtures/results.yaml
@@ -9,6 +9,7 @@ results:
     - cloud-launcher
     - database-launcher
     - control-plane-clouds
+    - grafana-controller
     - k8s-controller
     - otc
     - alerta

--- a/zuul.d/infra-prod.yaml
+++ b/zuul.d/infra-prod.yaml
@@ -208,6 +208,16 @@
       - playbooks/templates/grafana
 
 - job:
+    name: infra-prod-grafana-datasources
+    parent: infra-prod-service-base
+    description: Run grafana-datasources.yaml playbook.
+    vars:
+      playbook_name: grafana-datasources.yaml
+    files:
+      - playbooks/grafana-datasources.yaml
+      - playbooks/roles/grafana
+
+- job:
     name: infra-prod-service-grafana
     parent: infra-prod-service-base
     description: Run service-grafana.yaml playbook.

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -70,6 +70,11 @@
               - name: infra-prod-base
                 soft: true
 
+        - infra-prod-grafana-datasources: &infra-prod-grafana-datasources
+            dependencies:
+              - name: infra-prod-bootstrap-bridge
+                soft: true
+
         - infra-prod-install-cce: &infra-prod-install-cce
             dependencies:
               - name: infra-prod-base
@@ -173,6 +178,7 @@
         - infra-prod-install-helm-chart: *infra-prod-install-helm-chart
 
         - infra-prod-grafana-dashboards: *infra-prod-grafana-dashboards
+        - infra-prod-grafana-datasources: *infra-prod-grafana-datasources
 
         - infra-prod-service-acme-ssl: *infra-prod-service-acme-ssl
         - infra-prod-service-alerta: *infra-prod-service-alerta


### PR DESCRIPTION
Implement management of the grafana datasources:
- add grafana-controller group (with bridge in it) from where playbook
  is executed
- datasources are configured in the secret part of the inventory
- job is executed periodically to ensure secrets rotation