### PR TITLE
Ensure inventory of the sc2 exists

### DIFF
--- a/playbooks/bootstrap-bridge.yaml
+++ b/playbooks/bootstrap-bridge.yaml
@@ -28,3 +28,20 @@
           repo: openstack/ansible-collections-openstack
           git_provider: opendev.org
     - root-keys
+
+  tasks:
+    - name: Ensure sc2 folders
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: "directory"
+      loop:
+        - "/home/zuul/src/gitlab/ecosystem/system-config/inventory/base"
+        - "/home/zuul/src/gitlab/ecosystem/system-config/inventory/service"
+
+    - name: Ensure sc2 files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: "touch"
+      loop:
+        - "/home/zuul/src/gitlab/ecosystem/system-config/inventory/base/hosts.yaml"
+        - "/home/zuul/src/gitlab/ecosystem/system-config/inventory/service/groups.yaml"

--- a/playbooks/roles/hashivault/vars/Debian.yaml
+++ b/playbooks/roles/hashivault/vars/Debian.yaml
@@ -1,2 +1,3 @@
 ---
-packages: []
+packages:
+  - unzip


### PR DESCRIPTION
we need to ensure that even if sc2 is not checked out ansible will
be able to run.
