### PR TITLE
make k8 config not group readable

### DIFF
--- a/playbooks/roles/configure-kubectl/tasks/main.yaml
+++ b/playbooks/roles/configure-kubectl/tasks/main.yaml
@@ -12,4 +12,4 @@
     dest: '{{ kube_config_file }}'
     group: '{{ kube_config_group }}'
     owner: '{{ kube_config_owner }}'
-    mode: 0640
+    mode: 0600


### PR DESCRIPTION
Some tools complain over too open mode of the kube config file. Do it
600.
