### PR TITLE
Restructure grafana inventory

### DIFF
--- a/inventory/service/group_vars/grafana.yaml
+++ b/inventory/service/group_vars/grafana.yaml
@@ -1,14 +1,49 @@
-default: &default_vars
-  grafana_plugins: [ ]
-  grafana_enable_renderer: true
-  grafana_users_allow_sign_up: false
-  grafana_renderer_host: "renderer"
-  grafana_grafana_host: "grafana"
-  grafana_image: "{{ grafana_image_stable }}"
-  grafana_renderer_image: "{{ grafana_renderer_image_stable }}"
-  grafana_users_login_hint: "OTC LDAP account"
-  grafana_users_password_hint: "OTC LDAP password"
+# Grafana instances (clusters)
+grafana_instances:
+  ## Main dashboard
+  dashboard:
+    fqdn: "dashboard.tsi-dev.otc-service.com"
+    grafana_cert: "grafana"
+    grafana_enable_renderer: true
+    grafana_grafana_host: "grafana"
+    grafana_image: "{{ grafana_image_stable }}"
+    grafana_plugins: [ ]
+    grafana_renderer_host: "renderer"
+    grafana_renderer_image: "{{ grafana_renderer_image_stable }}"
+    grafana_url: "https://dashboard.tsi-dev.otc-service.com"
+    grafana_users_login_hint: "OTC LDAP account"
+    grafana_users_password_hint: "OTC LDAP password"
 
+  # Staging env
+  dashboard_stg:
+    cluster_issuer: "letsencrypt-staging"
+    fqdn: "dashboard.apps.osinfra-stg.eco.tsi-dev.otc-service.com"
+    grafana_enable_renderer: true
+    grafana_grafana_host: "grafana"
+    grafana_image: "{{ grafana_image_stable }}"
+    grafana_plugins: [ ]
+    grafana_renderer_host: "renderer"
+    grafana_renderer_image: "{{ grafana_renderer_image_stable }}"
+    grafana_url: "https://dashboard.apps.osinfra-stg.eco.tsi-dev.otc-service.com"
+    grafana_users_login_hint: "OTC LDAP account"
+    grafana_users_password_hint: "OTC LDAP password"
+
+  # Infra dashboard
+  dashboard_infra:
+    fqdn: "dashboard.eco.tsi-dev.otc-service.com"
+    grafana_cert: "grafana-eco"
+    grafana_enable_renderer: true
+    grafana_grafana_host: "grafana"
+    grafana_image: "{{ grafana_image_stable }}"
+    grafana_plugins: [ ]
+    grafana_renderer_host: "renderer"
+    grafana_renderer_image: "{{ grafana_renderer_image_stable }}"
+    grafana_url: "https://dashboard.eco.tsi-dev.otc-service.com"
+    grafana_users_login_hint: "Username"
+    grafana_users_password_hint: "Password"
+
+# Extra vars for k8 deployment
+grafana_k8s_extra_vars:
   grafana_deployment_count: 2
   grafana_deployment_resources:
     limits:
@@ -25,44 +60,29 @@ default: &default_vars
       cpu: 100m
       memory: 100Mi
 
-grafana_instances:
-  production_stg:
-    cluster_issuer: "letsencrypt-staging"
-    fqdn: dashboard.apps.osinfra-stg.eco.tsi-dev.otc-service.com
-    default: *default_vars
-  production_infra:
-    # cluster_issuer: "letsencrypt-prod"
-    fqdn: "dashboard.tsi-dev.otc-service.com"
-    grafana_cert: "grafana"
-    default: *default_vars
-  production_infra-mirror:
-    # cluster_issuer: "letsencrypt-prod"
-    fqdn: "dashboard.tsi-dev.otc-service.com"
-    grafana_cert: "grafana"
-    default: *default_vars
-  production_vc:
-    default: *default_vars
-  production_infra-eco:
-    default: *default_vars
-    fqdn: "dashboard.eco.tsi-dev.otc-service.com"
-    grafana_cert: "grafana-eco"
-    grafana_users_login_hint: "Username"
-    grafana_users_password_hint: "Password"
-
+# Grafana map of instances to K8 installations
 grafana_k8s_instances:
-  - grafana_instance: "production_stg"
+  # Stg grafana in stg cluster
+  - grafana_instance: "dashboard_stg"
     instance: "stg"
     context: "otcinfra-stg"
     namespace: "apimon"
-  - grafana_instance: "production_infra"
+    extra_vars: "{{ grafana_k8s_extra_vars }}"
+  # Main grafana in main cluster
+  - grafana_instance: "dashboard"
     instance: "prod"
     context: "otcinfra"
     namespace: "apimon"
-  - grafana_instance: "production_infra-mirror"
+    extra_vars: "{{ grafana_k8s_extra_vars }}"
+  # Main grafana in mirror cluster
+  - grafana_instance: "dashboard"
     instance: "prod-mirror"
     context: "otcinfra-mirror"
     namespace: "apimon"
-  - grafana_instance: "production_infra-eco"
+    extra_vars: "{{ grafana_k8s_extra_vars }}"
+  # Infra grafana in main cluster
+  - grafana_instance: "dashboard_infra"
     instance: "prod-eco"
     context: "otcinfra"
     namespace: "grafana-eco"
+    extra_vars: "{{ grafana_k8s_extra_vars }}"

--- a/inventory/service/host_vars/web3.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/web3.eco.tsi-dev.otc-service.com.yaml
@@ -1,5 +1,7 @@
 alerta_instance: "production_vc"
-grafana_instance: "production_vc"
+grafana_instance: "dashboard"
+grafana_instance_extra_vars: {}
+
 ssl_certs:
   web3:
     - "web3.eco.tsi-dev.otc-service.com"

--- a/playbooks/dashboards.yaml
+++ b/playbooks/dashboards.yaml
@@ -7,8 +7,8 @@
         grafana_dashboard_content: "{{ lookup('template', 'templates/grafana/' + item + '.j2') | from_yaml }}"
         grafana_dashboard_folder: "Apimon"
         grafana_ds: "apimon-carbonapi"
-        grafana_url: "{{ grafana_api_instance_dashboard.url }}"
-        grafana_api_token: "{{ grafana_api_instance_dashboard.api_token }}"
+        grafana_url: "{{ grafana_instances.dashboard.grafana_url }}"
+        grafana_api_token: "{{ grafana_instance_dashboard_api_token }}"
       loop:
         - apimon/test_results.yaml
         - apimon/endpoint_monitor.yaml
@@ -26,5 +26,7 @@
         grafana_dashboard_content: "{{ lookup('template', 'templates/grafana/' + item + '.j2') | from_yaml }}"
         grafana_dashboard_folder: "Internal monitoring"
         grafana_ds: "apimon-carbonapi"
+        grafana_url: "{{ grafana_instances.dashboard.grafana_url }}"
+        grafana_api_token: "{{ grafana_instance_dashboard_api_token }}"
       loop:
         - monitoring/internal_monitoring.yaml

--- a/playbooks/roles/grafana/defaults/main.yml
+++ b/playbooks/roles/grafana/defaults/main.yml
@@ -11,9 +11,13 @@ grafana_uid_prefix: ""
 
 state: "present"
 
+grafana_users_allow_sign_up: false
+
 grafana_config_name: "grafana-config-{{ instance }}"
 grafana_secret_name: "grafana-secret-{{ instance }}"
 grafana_deployment_name: "grafana-deployment-{{ instance }}"
 grafana_service_name: "grafana-service-{{ instance }}"
 grafana_ingress_name: "grafana-ingress-{{ instance }}"
 grafana_ssl_cert_name: "grafana-ssl-{{ instance }}"
+
+

--- a/playbooks/roles/grafana/tasks/import_ds.yaml
+++ b/playbooks/roles/grafana/tasks/import_ds.yaml
@@ -3,8 +3,8 @@
     state: "present"
     name: "{{ grafana_datasource_name }}"
 
-    grafana_url: "{{ grafana_datasource_content.url }}"
-    grafana_api_key: "{{ grafana_datasource_content.api_key }}"
+    grafana_url: "{{ grafana_datasource_content.grafana_url }}"
+    grafana_api_key: "{{ grafana_datasource_content.grafana_api_key }}"
 
     ds_type: "{{ grafana_datasource_content.ds_type }}"
     ds_url: "{{ grafana_datasource_content.ds_url }}"

--- a/playbooks/roles/grafana/tasks/k8s.yaml
+++ b/playbooks/roles/grafana/tasks/k8s.yaml
@@ -23,9 +23,9 @@
           app.kubernetes.io/managed-by: "system-config"
       data:
         ldap.toml: "{{ lookup('template', 'templates/grafana/ldap.toml.j2') }}"
-        ldap-certificate.crt: "{{ grafana.grafana_auth_ldap_certificate | default(grafana.default.grafana_auth_ldap_certificate) }}"
+        ldap-certificate.crt: "{{ grafana.grafana_auth_ldap_certificate }}"
   when:
-    - (grafana.grafana_ldap_enable is defined and grafana.grafana_ldap_enable) or (grafana.grafana_ldap_enable is undefined and grafana.default.grafana_ldap_enable)
+    - (grafana.grafana_ldap_enable is defined and grafana.grafana_ldap_enable)
 
 - name: Create {{ instance }} Secrets
   community.kubernetes.k8s:

--- a/playbooks/roles/grafana/tasks/main.yml
+++ b/playbooks/roles/grafana/tasks/main.yml
@@ -74,13 +74,14 @@
 - name: Write Grafana ldap root CA file
   become: true
   copy:
-    content: "{{ grafana.grafana_auth_ldap_certificate | default(grafana.default.grafana_auth_ldap_certificate) }}"
+    content: "{{ grafana.grafana_auth_ldap_certificate }}"
     dest: "/etc/grafana/ldap/ldap-certificate.crt"
     owner: "{{ grafana_os_user }}"
     group: "{{ grafana_os_group }}"
     mode: 0664
   when:  
-    - (grafana.grafana_auth_ldap_certificate is defined and grafana.grafana_auth_ldap_certificate |length > 0)  or (grafana.default.grafana_auth_ldap_certificate is defined and grafana.default.grafana_auth_ldap_certificate |length > 0)
+    - "grafana.grafana_auth_ldap_certificate is defined"
+    - "grafana.grafana_auth_ldap_certificate |length > 0"
   notify:
     - restart grafana
 
@@ -90,7 +91,8 @@
     src: "grafana-renderer.service.j2"
     dest: "/etc/systemd/system/grafana-renderer.service"
   when: 
-    - (grafana.grafana_enable_renderer is defined and grafana.grafana_enable_renderer) or (grafana.grafana_enable_renderer is undefined and grafana.default.grafana_enable_renderer) 
+    - "grafana.grafana_enable_renderer is defined"
+    - "grafana.grafana_enable_renderer"
   notify:
     - restart grafana-renderer
 
@@ -122,7 +124,7 @@
   become: true
   become_user: "{{ grafana_os_user }}"
   command: "{{ container_command }} exec grafana grafana-cli plugins install {{ item }}"
-  loop: "{{ grafana.default.grafana_plugins }}"
+  loop: "{{ grafana.grafana_plugins }}"
   notify:
     - restart grafana
 

--- a/playbooks/roles/grafana/templates/env.j2
+++ b/playbooks/roles/grafana/templates/env.j2
@@ -1,42 +1,38 @@
-GRAFANA_IMAGE={{ grafana.grafana_image | default(grafana.default.grafana_image) }}
-GRAFANA_RENDERER_IMAGE={{ grafana.grafana_renderer_image | default(grafana.default.grafana_renderer_image) }}
+GRAFANA_IMAGE={{ grafana.grafana_image }}
+GRAFANA_RENDERER_IMAGE={{ grafana.grafana_renderer_image }}
 
-{% if (grafana.grafana_server_root_url is defined and grafana.grafana_server_root_url|length) or
-      (grafana.default.grafana_server_root_url is defined and grafana.default.grafana_server_root_url|length) %}
-GF_SERVER_ROOT_URL={{ grafana.grafana_server_root_url | default(grafana.default.grafana_server_root_url) }}
+{% if (grafana.grafana_url is defined and grafana.grafana_url|length)  %}
+GF_SERVER_ROOT_URL={{ grafana.grafana_url }}
 {% endif %}
 GF_SERVER_ENABLE_GZIP=true
 # Initial admin password. Must be changed afterwards
-GF_SECURITY_ADMIN_PASSWORD={{ grafana.grafana_security_admin_password | default(grafana.default.grafana_security_admin_password) }}
-GF_USERS_ALLOW_SIGN_UP={{ grafana.grafana_users_allow_sign_up | default(grafana.default.grafana_users_allow_sign_up) }}
+GF_SECURITY_ADMIN_PASSWORD={{ grafana.grafana_security_admin_password}}
+GF_USERS_ALLOW_SIGN_UP={{ grafana.grafana_users_allow_sign_up | default(false) }}
 
-GF_USERS_LOGIN_HINT={{ grafana.grafana_users_login_hint | default(grafana.default.grafana_users_login_hint)  }}
-GF_USERS_PASSWORD_HINT={{ grafana.grafana_users_password_hint | default(grafana.default.grafana_users_password_hint) }}
+GF_USERS_LOGIN_HINT={{ grafana.grafana_users_login_hint }}
+GF_USERS_PASSWORD_HINT={{ grafana.grafana_users_password_hint }}
 
-{% if (grafana.grafana_db_url is defined and grafana.grafana_db_url|length) or
-      (grafana.default.grafana_db_url is defined and grafana.default.grafana_db_url|length) %}
-GF_DATABASE_URL={{ grafana.grafana_db_url | default(grafana.default.grafana_db_url) }}
+{% if (grafana.grafana_db_url is defined and grafana.grafana_db_url|length) %}
+GF_DATABASE_URL={{ grafana.grafana_db_url }}
 {% endif %}
 
-{% if (grafana.grafana_auth_github_enable is defined and grafana.grafana_auth_github_enable) or
-      (grafana.default.grafana_auth_github_enable is defined and grafana.default.grafana_auth_github_enable) %}
+{% if (grafana.grafana_auth_github_enable is defined and grafana.grafana_auth_github_enable) %}
 GF_AUTH_GITHUB_ENABLED=true
 GF_AUTH_GITHUB_ALLOW_SIGN_UP=true
-GF_AUTH_GITHUB_CLIENT_ID={{ grafana.grafana_auth_github_client_id | default(grafana.default.grafana_auth_github_client_id) }}
-GF_AUTH_GITHUB_CLIENT_SECRET={{ grafana.grafana_auth_github_client_secret | default(grafana.default.grafana_auth_github_client_secret) }}
+GF_AUTH_GITHUB_CLIENT_ID={{ grafana.grafana_auth_github_client_id }}
+GF_AUTH_GITHUB_CLIENT_SECRET={{ grafana.grafana_auth_github_client_secret }}
 GF_AUTH_GITHUB_SCOPES=user:email,read:org
 GF_AUTH_GITHUB_AUTH_URL=https://github.com/login/oauth/authorize
 GF_AUTH_GITHUB_TOKEN_URL=https://github.com/login/oauth/access_token
 GF_AUTH_GITHUB_API_URL=https://api.github.com/user
-GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS={{ grafana.grafana_auth_github_allowed_orgs | default(grafana.default.grafana_auth_github_allowed_orgs) }}
+GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS={{ grafana.grafana_auth_github_allowed_orgs }}
 {% endif %}
 
-{% if (grafana.grafana_smtp_enable is defined and grafana.grafana_smtp_enable) or
-      (grafana.default.grafana_smtp_enable is defined and grafana.default.grafana_smtp_enable) %}
+{% if (grafana.grafana_smtp_enable is defined and grafana.grafana_smtp_enable) %}
 GF_SMTP_ENABLED=true
-GF_SMTP_HOST={{ grafana.grafana_smtp_host | default(grafana.default.grafana_smtp_host) }}
-GF_SMTP_FROM_ADDRESS={{ grafana.grafana_smtp_from_address | default(grafana.default.grafana_smtp_from_address) }}
-GF_SMTP_FROM_NAME={{ grafana.grafana_smtp_from_name | default(grafana.default.grafana_smtp_from_name) }}
+GF_SMTP_HOST={{ grafana.grafana_smtp_host }}
+GF_SMTP_FROM_ADDRESS={{ grafana.grafana_smtp_from_address }}
+GF_SMTP_FROM_NAME={{ grafana.grafana_smtp_from_name }}
 {% endif %}
 
 {% if grafana_ldap_config is defined and grafana_ldap_config|length %}
@@ -45,6 +41,6 @@ GF_AUTH_LDAP_ALLOW_SIGN_UP=true
 GF_AUTH_LDAP_CONFIG_FILE=/etc/grafana/ldap/ldap.toml
 {% endif %}
 
-GF_RENDERING_SERVER_URL=http://{{ grafana.grafana_renderer_host | default(grafana.default.grafana_renderer_host) }}:8081/render
-GF_RENDERING_CALLBACK_URL=http://{{ grafana.grafana_grafana_host | default(grafana.default.grafana_grafana_host) }}:3000/
+GF_RENDERING_SERVER_URL=http://{{ grafana.grafana_renderer_host }}:8081/render
+GF_RENDERING_CALLBACK_URL=http://{{ grafana.grafana_grafana_host}}:3000/
 GF_LOG_FILTERS=rendering:debug

--- a/playbooks/roles/grafana/templates/grafana-deployment.yaml.j2
+++ b/playbooks/roles/grafana/templates/grafana-deployment.yaml.j2
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: "{{ instance }}"
     app.kubernetes.io/managed-by: "system-config"
 spec:
-  replicas: {{ (grafana.grafana_deployment_count | default(grafana.default.grafana_deployment_count))|int }}
+  replicas: {{ grafana.grafana_deployment_count | int }}
   selector:
     matchLabels:
       app.kubernetes.io/name: "grafana"
@@ -42,7 +42,7 @@ spec:
                   - "{{ instance }}"
               topologyKey: kubernetes.io/hostname
       containers:
-      - image: "{{ grafana.grafana_renderer_image | default(grafana.default.grafana_renderer_image) }}" 
+      - image: "{{ grafana.grafana_renderer_image }}" 
         name: "grafana-renderer"
         ports:
         - containerPort: 8081
@@ -54,30 +54,14 @@ spec:
             {{ key2 }}: {{ value2 }}
 {% endfor %}
 {% endfor %}
-{% else %}
-        resources:
-{% for key, value in grafana.default.renderer_deployment_resources.items() %}
-          {{ key }}:
-{% for key2, value2 in value.items() %}
-            {{ key2 }}: {{ value2 }}
-{% endfor %}
-{% endfor %}
 {% endif %}
-      - image: "{{ grafana.grafana_image | default(grafana.default.grafana_image) }}"
+      - image: "{{ grafana.grafana_image }}"
         name: grafana
         ports:
         - containerPort: 3000
 {% if grafana.grafana_deployment_resources is defined %}
         resources:
 {% for key, value in grafana.grafana_deployment_resources.items() %}
-          {{ key }}:
-{% for key2, value2 in value.items() %}
-            {{ key2 }}: {{ value2 }}
-{% endfor %}
-{% endfor %}
-{% else %}
-        resources:
-{% for key, value in grafana.default.grafana_deployment_resources.items() %}
           {{ key }}:
 {% for key2, value2 in value.items() %}
             {{ key2 }}: {{ value2 }}
@@ -99,18 +83,14 @@ spec:
             value: http://localhost:8081/render
           - name: GF_RENDERING_CALLBACK_URL
             value: http://{{ grafana.fqdn }}:3000
-{% if (grafana.grafana_plugins is defined and grafana.grafana_plugins|length) or
-      (grafana.default.grafana_plugins is defined and grafana.default.grafana_plugins|length)
-%}
+{% if (grafana.grafana_plugins is defined and grafana.grafana_plugins|length) %}
           - name: GF_INSTALL_PLUGINS
-            value: "{{ grafana.grafana_plugins | default(grafana.default.grafana_plugins) }}"
+            value: "{{ grafana.grafana_plugins }}"
 {% endif %}
         envFrom:
         - secretRef:
             name: "{{ grafana_secret_name }}"
-{% if (grafana.grafana_ldap_enable is defined and grafana.grafana_ldap_enable) or
-      (grafana.grafana_ldap_enable is undefined and grafana.default.grafana_ldap_enable)
-%}
+{% if (grafana.grafana_ldap_enable is defined and grafana.grafana_ldap_enable) %}
         volumeMounts:
         - name: grafana-config
           mountPath: /etc/grafana/ldap/ldap.toml

--- a/playbooks/roles/grafana/templates/grafana-renderer.service.j2
+++ b/playbooks/roles/grafana/templates/grafana-renderer.service.j2
@@ -23,10 +23,6 @@ ExecStart={{ container_runtime }} run \
 {% for item in grafana.grafana_renderer_hosts_entries %}
     --add-host={{ item }} \
 {% endfor %}
-{% elif grafana.default.grafana_renderer_hosts_entries is defined and grafana.default.grafana_renderer_hosts_entries|length %}
-{% for item in grafana.default.grafana_renderer_hosts_entries %}
-    --add-host={{ item }} \
-{% endfor %}
 {% else %}
    --add-host=grafana:{{ ansible_default_ipv4.address }} \
 {% endif %}

--- a/playbooks/roles/grafana/templates/grafana-secret.yaml.j2
+++ b/playbooks/roles/grafana/templates/grafana-secret.yaml.j2
@@ -6,51 +6,44 @@ metadata:
     app.kubernetes.io/instance: "{{ instance }}"
     app.kubernetes.io/managed-by: "system-config"
 data:
-{% if (grafana.grafana_server_root_url is defined and grafana.grafana_server_root_url|length) or
-      (grafana.default.grafana_server_root_url is defined and grafana.default.grafana_server_root_url|length) %}
-  GF_SERVER_ROOT_URL: "{{ grafana.grafana_server_root_url | default(grafana.default.grafana_server_root_url) | string | b64encode }}"
+{% if (grafana.grafana_url is defined and grafana.grafana_url|length) %}
+  GF_SERVER_ROOT_URL: "{{ grafana.grafana_url | string | b64encode }}"
 {% endif %}
-{% if (grafana.grafana_server_domain is defined and grafana.grafana_server_domain|length) or
-      (grafana.default.grafana_server_domain is defined and grafana.default.grafana_server_domain|length) %}
-  GF_SERVER_DOMAIN: "{{ grafana.grafana_server_domain | default(grafana.default.grafana_server_domain) | string | b64encode }}"
+{% if (grafana.fqdn is defined and grafana.fqdn|length) %}
+  GF_SERVER_DOMAIN: "{{ grafana.fqdn | string | b64encode }}"
 {% endif %}
   GF_SERVER_ENABLE_GZIP: "{{ 'true' | string | b64encode }}"
-  GF_SECURITY_ADMIN_PASSWORD: "{{ grafana.grafana_security_admin_password | default(grafana.default.grafana_security_admin_password) | string | b64encode }}"
-  GF_USERS_ALLOW_SIGN_UP: "{{ grafana.grafana_users_allow_sign_up | default(grafana.default.grafana_users_allow_sign_up) | string | b64encode }}"
+  GF_SECURITY_ADMIN_PASSWORD: "{{ grafana.grafana_security_admin_password | string | b64encode }}"
+  GF_USERS_ALLOW_SIGN_UP: "{{ grafana.grafana_users_allow_sign_up | default(false) | string | b64encode }}"
 
-  GF_USERS_LOGIN_HINT: "{{ grafana.grafana_users_login_hint | default(grafana.default.grafana_users_login_hint) | string | b64encode  }}"
-  GF_USERS_PASSWORD_HINT: "{{ grafana.grafana_users_password_hint | default(grafana.default.grafana_users_password_hint) | string | b64encode }}"
+  GF_USERS_LOGIN_HINT: "{{ grafana.grafana_users_login_hint | string | b64encode  }}"
+  GF_USERS_PASSWORD_HINT: "{{ grafana.grafana_users_password_hint | string | b64encode }}"
 
-{% if (grafana.grafana_db_url is defined and grafana.grafana_db_url|length) or
-      (grafana.default.grafana_db_url is defined and grafana.default.grafana_db_url|length) %}
-  GF_DATABASE_URL: "{{ grafana.grafana_db_url | default(grafana.default.grafana_db_url) | string | b64encode }}"
+{% if (grafana.grafana_db_url is defined and grafana.grafana_db_url|length)  %}
+  GF_DATABASE_URL: "{{ grafana.grafana_db_url | string | b64encode }}"
 {% endif %}
 
-{% if (grafana.grafana_auth_github_enable is defined and grafana.grafana_auth_github_enable) or
-      (grafana.default.grafana_auth_github_enable is defined and grafana.default.grafana_auth_github_enable) %}
+{% if (grafana.grafana_auth_github_enable is defined and grafana.grafana_auth_github_enable) %}
   GF_AUTH_GITHUB_ENABLED: "{{ 'true' | string | b64encode }}"
   GF_AUTH_GITHUB_ALLOW_SIGN_UP: "{{ 'true' | string | b64encode }}"
-  GF_AUTH_GITHUB_CLIENT_ID: "{{ grafana.grafana_auth_github_client_id | default(grafana.default.grafana_auth_github_client_id) | string | b64encode }}"
-  GF_AUTH_GITHUB_CLIENT_SECRET: "{{ grafana.grafana_auth_github_client_secret | default(grafana.default.grafana_auth_github_client_secret) | string | b64encode }}"
+  GF_AUTH_GITHUB_CLIENT_ID: "{{ grafana.grafana_auth_github_client_id | string | b64encode }}"
+  GF_AUTH_GITHUB_CLIENT_SECRET: "{{ grafana.grafana_auth_github_client_secret | string | b64encode }}"
   GF_AUTH_GITHUB_SCOPES: "{{ 'user:email,read:org' | string | b64encode }}"
   GF_AUTH_GITHUB_AUTH_URL: "{{ 'https://github.com/login/oauth/authorize'  | string | b64encode }}"
   GF_AUTH_GITHUB_TOKEN_URL: "{{ 'https://github.com/login/oauth/access_token' | string | b64encode }}"
   GF_AUTH_GITHUB_API_URL: "{{ 'https://api.github.com/user' | string | b64encode }}"
-  GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS: "{{ grafana.grafana_auth_github_allowed_orgs | default(grafana.default.grafana_auth_github_allowed_orgs) | string | b64encode }}"
+  GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS: "{{ grafana.grafana_auth_github_allowed_orgs | string | b64encode }}"
 {% endif %}
 
-{% if (grafana.grafana_smtp_enable is defined and grafana.grafana_smtp_enable) or
-      (grafana.default.grafana_smtp_enable is defined and grafana.default.grafana_smtp_enable) %}
+{% if (grafana.grafana_smtp_enable is defined and grafana.grafana_smtp_enable) %}
   GF_SMTP_ENABLED: "{{ 'true' | string | b64encode }}"
-  GF_SMTP_HOST: "{{ grafana.grafana_smtp_host | default(grafana.default.grafana_smtp_host) | string | b64encode }}"
-  GF_SMTP_FROM_ADDRESS: "{{ grafana.grafana_smtp_from_address | default(grafana.default.grafana_smtp_from_address) | string | b64encode }}"
-  GF_SMTP_FROM_NAME: "{{ grafana.grafana_smtp_from_name | default(grafana.default.grafana_smtp_from_name) | string | b64encode }}"
+  GF_SMTP_HOST: "{{ grafana.grafana_smtp_host | string | b64encode }}"
+  GF_SMTP_FROM_ADDRESS: "{{ grafana.grafana_smtp_from_address | string | b64encode }}"
+  GF_SMTP_FROM_NAME: "{{ grafana.grafana_smtp_from_name | string | b64encode }}"
 {% endif %}
 
-{% if (grafana.grafana_ldap_enable is defined and grafana.grafana_ldap_enable) or
-      (grafana.grafana_ldap_enable is undefined and grafana.default.grafana_ldap_enable) %}
+{% if (grafana.grafana_ldap_enable is defined and grafana.grafana_ldap_enable) %}
   GF_AUTH_LDAP_ENABLED: "{{ 'true' | string | b64encode }}"
   GF_AUTH_LDAP_ALLOW_SIGN_UP: "{{ 'true' | string | b64encode }}"
   GF_AUTH_LDAP_CONFIG_FILE: "{{ '/etc/grafana/ldap/ldap.toml' | string | b64encode }}"
 {% endif %}
-

--- a/playbooks/roles/grafana/templates/grafana.service.j2
+++ b/playbooks/roles/grafana/templates/grafana.service.j2
@@ -20,13 +20,13 @@ ExecStart={{ container_runtime }} run \
     --log-opt=path=/dev/null \
 {% endif %}
 {% if grafana_ldap_config is defined and grafana_ldap_config|length %}
-{% if grafana.grafana_auth_ldap_hosts_entry is defined or grafana.default.grafana_auth_ldap_hosts_entry is defined %}
-    --add-host={{ grafana.grafana_auth_ldap_hosts_entry | default(grafana.default.grafana_auth_ldap_hosts_entry) }} \
+{% if grafana.grafana_auth_ldap_hosts_entry is defined %}
+    --add-host={{ grafana.grafana_auth_ldap_hosts_entry }} \
 {% endif %}
 {% endif %}
-{% if (grafana.grafana_enable_renderer is defined and grafana.grafana_enable_renderer) or (grafana.default.grafana_enable_renderer is defined and grafana.default.grafana_enable_renderer ) %}
-{% if grafana.grafana_renderer_hosts_entry is defined or grafana.default.grafana_renderer_hosts_entry is defined %}
-    --add-host={{ grafana.grafana_renderer_hosts_entry | default(grafana.default.grafana_renderer_hosts_entry) }} \
+{% if (grafana.grafana_enable_renderer is defined and grafana.grafana_enable_renderer) %}
+{% if grafana.grafana_renderer_hosts_entry is defined  %}
+    --add-host={{ grafana.grafana_renderer_hosts_entry}} \
 {% else %}
     --add-host=renderer:{{ ansible_default_ipv4.address }} \
 {% endif %}

--- a/playbooks/service-grafana.yaml
+++ b/playbooks/service-grafana.yaml
@@ -1,9 +1,13 @@
-# On all hosts in grafan group except those also in k8s-controller
+# On all hosts in grafana group except those also in k8s-controller
 - hosts: "grafana:!disabled:!k8s-controller"
   become: true
   name: "Base: configure grafana"
   vars:
-    grafana: "{{ grafana_instances[grafana_instance] | combine(grafana_instances_secrets[grafana_instance], recursive=True) }}"
+    grafana: "{{ grafana_instances[grafana_instance]
+        | combine((grafana_instances_secrets[grafana_instance]|default({})), recursive=True)
+        | combine((grafana_instance_extra_vars|default({})), recursive=True)
+        | combine((grafana_instance_extra_secret_vars|default({})), recursive=True)
+      }}"
   roles:
     # Group should be responsible for defining open ports
     - role: firewalld
@@ -19,7 +23,11 @@
         name: "grafana"
         tasks_from: "k8s.yaml"
       vars:
-        grafana: "{{ grafana_instances[item.grafana_instance] | combine(grafana_instances_secrets[item.grafana_instance], recursive=True) }}"
+        grafana: "{{ grafana_instances[item.grafana_instance]
+            | combine((grafana_instances_secrets[item.grafana_instance]|default({})), recursive=True)
+            | combine((item.extra_vars|default({})), recursive=True)
+            | combine((grafana_instances_extra_secret_vars[item.instance]|default({})), recursive=True)
+          }}"
         instance: "{{ item.instance }}"
         context: "{{ item.context }}"
         namespace: "{{ item.namespace }}"

--- a/playbooks/templates/grafana/ldap.toml.j2
+++ b/playbooks/templates/grafana/ldap.toml.j2
@@ -1,20 +1,20 @@
 [[servers]]
-host = {{ grafana.grafana_auth_ldap_host | default(grafana.default.grafana_auth_ldap_host) }}
+host = {{ grafana.grafana_auth_ldap_host }}
 port = 636
 use_ssl = true
 start_tls = false
 ssl_skip_verify = false
 root_ca_cert = "/etc/grafana/ldap/ldap-certificate.crt"
 
-bind_dn = {{ grafana.grafana_auth_ldap_bind_dn | default(grafana.default.grafana_auth_ldap_bind_dn) }}
-bind_password = "{{ grafana.grafana_auth_ldap_bind_password | default(grafana.default.grafana_auth_ldap_bind_password) }}"
+bind_dn = {{ grafana.grafana_auth_ldap_bind_dn }}
+bind_password = "{{ grafana.grafana_auth_ldap_bind_password }}"
 
-search_filter = {{ grafana.grafana_auth_ldap_search_filter | default(grafana.default.grafana_auth_ldap_search_filter) }}
-search_base_dns = {{ grafana.grafana_auth_ldap_search_base_dns | default(grafana.default.grafana_auth_ldap_search_base_dns) }}
+search_filter = {{ grafana.grafana_auth_ldap_search_filter }}
+search_base_dns = {{ grafana.grafana_auth_ldap_search_base_dns }}
 
-group_search_filter = {{ grafana.grafana_auth_ldap_group_search_filter | default(grafana.default.grafana_auth_ldap_group_search_filter) }}
-group_search_filter_user_attribute = {{ grafana.grafana_auth_ldap_group_search_filter_user_attribute | default(grafana.default.grafana_auth_ldap_group_search_filter_user_attribute) }}
-group_search_base_dns = {{ grafana.grafana_auth_ldap_group_search_base_dns | default(grafana.default.grafana_auth_ldap_group_search_base_dns) }}
+group_search_filter = {{ grafana.grafana_auth_ldap_group_search_filter }}
+group_search_filter_user_attribute = {{ grafana.grafana_auth_ldap_group_search_filter_user_attribute }}
+group_search_base_dns = {{ grafana.grafana_auth_ldap_group_search_base_dns }}
 
 # Specify names of the ldap attributes your ldap uses
 [servers.attributes]
@@ -24,18 +24,18 @@ username = "uid"
 email =  "mail"
 
 [[servers.group_mappings]]
-group_dn = {{ grafana.grafana_auth_ldap_group_dn_super_admin |default(grafana.default.grafana_auth_ldap_group_dn_super_admin) }}
+group_dn = {{ grafana.grafana_auth_ldap_group_dn_super_admin }}
 org_role = "Admin"
 grafana_admin = true
 org_id = 1
 
 [[servers.group_mappings]]
-group_dn = {{ grafana.grafana_auth_ldap_group_dn_admin | default(grafana.default.grafana_auth_ldap_group_dn_admin) }}
+group_dn = {{ grafana.grafana_auth_ldap_group_dn_admin }}
 org_role = "Admin"
 org_id = 1
 
 [[servers.group_mappings]]
-group_dn = {{ grafana.grafana_auth_ldap_group_dn_editor | default(grafana.default.grafana_auth_ldap_group_dn_editor) }}
+group_dn = {{ grafana.grafana_auth_ldap_group_dn_editor }}
 org_role = "Editor"
 org_id = 1
 
@@ -43,4 +43,3 @@ org_id = 1
 group_dn = "*"
 org_role = "Viewer"
 org_id = 1
-

--- a/playbooks/zuul/templates/group_vars/grafana.yaml.j2
+++ b/playbooks/zuul/templates/group_vars/grafana.yaml.j2
@@ -1,6 +1,6 @@
 firewalld_extra_ports_enable: ['3000/tcp', '8081/tcp']
 grafana_instances_secrets:
-  production_vc:
+  dashboard:
     grafana_security_admin_password: foobar
     grafana_auth_github_enable: true
     grafana_auth_github_client_id: grafana
@@ -21,6 +21,6 @@ grafana_instances_secrets:
     grafana_auth_ldap_group_dn_editor: "cn=grafana-editors,ou=group,dc=example,dc=com"
     grafana_auth_ldap_group_search_base_dns: [ "cn=grafana-super-admins,ou=group,dc=example,dc=com", "cn=grafana-admins,ou=group,dc=example,dc=com", "cn=grafana-editors,ou=group,dc=example,dc=com" ]
 
-grafana_instance: production_vc
+grafana_instance: dashboard
 # disable k8 in tests
 grafana_k8s_instances: []


### PR DESCRIPTION
Apply same inventory style for grafana as for other services: 1 instance
represent whole "cluster/service". To address necessity to override
installation vars add support for extra_vars which behave similar to
host_vars.
