### PR TITLE
Fix wrong extra vars variable name in grafana

### DIFF
--- a/inventory/service/group_vars/grafana.yaml
+++ b/inventory/service/group_vars/grafana.yaml
@@ -62,12 +62,6 @@ grafana_k8s_extra_vars:
 
 # Grafana map of instances to K8 installations
 grafana_k8s_instances:
-  # Stg grafana in stg cluster
-  - grafana_instance: "dashboard_stg"
-    instance: "stg"
-    context: "otcinfra-stg"
-    namespace: "apimon"
-    extra_vars: "{{ grafana_k8s_extra_vars }}"
   # Main grafana in main cluster
   - grafana_instance: "dashboard"
     instance: "prod"
@@ -78,6 +72,12 @@ grafana_k8s_instances:
   - grafana_instance: "dashboard"
     instance: "prod-mirror"
     context: "otcinfra-mirror"
+    namespace: "apimon"
+    extra_vars: "{{ grafana_k8s_extra_vars }}"
+  # Stg grafana in stg cluster
+  - grafana_instance: "dashboard_stg"
+    instance: "stg"
+    context: "otcinfra-stg"
     namespace: "apimon"
     extra_vars: "{{ grafana_k8s_extra_vars }}"
   # Infra grafana in main cluster

--- a/playbooks/service-grafana.yaml
+++ b/playbooks/service-grafana.yaml
@@ -26,7 +26,7 @@
         grafana: "{{ grafana_instances[item.grafana_instance]
             | combine((grafana_instances_secrets[item.grafana_instance]|default({})), recursive=True)
             | combine((item.extra_vars|default({})), recursive=True)
-            | combine((grafana_instances_extra_secret_vars[item.instance]|default({})), recursive=True)
+            | combine((grafana_k8s_instances_extra_secret_vars[item.instance]|default({})), recursive=True)
           }}"
         instance: "{{ item.instance }}"
         context: "{{ item.context }}"


### PR DESCRIPTION
Last PR accidentially tried to get extra vars using wrong var name.
