### PR TITLE
Stop installing openshift python lib to bridge

### DIFF
--- a/playbooks/roles/install-ansible/tasks/main.yaml
+++ b/playbooks/roles/install-ansible/tasks/main.yaml
@@ -123,10 +123,6 @@
     version: '{{ _install_ansible_openstacksdk_version | default(omit) }}'
     state: '{{ _install_openstacksdk_state | default(omit) }}'
 
-- name: Install openshift client lib for k8s modules
-  pip:
-    name: 'openshift'
-
 # NOTE(ianw) 2021-03-03 stevedore < 3.3.0 has a bug where it creates a
 # constantly expanding set of cache files in
 # /root/.cache/python-endpoints when run under ansible in a /tmp


### PR DESCRIPTION
K8 modules are not really depending on openshift lib anymore, instead
they use kubernetes python lib. Now even installing openshift started
failing, therefore let's get rid of it.
