### PR TITLE
Disable hosts from provisioning

### DIFF
--- a/inventory/service/groups.yaml
+++ b/inventory/service/groups.yaml
@@ -204,3 +204,7 @@ groups:
     - zk1.zuul.eco.tsi-dev.otc-service.com
     - zk2.zuul.eco.tsi-dev.otc-service.com
     - zk3.zuul.eco.tsi-dev.otc-service.com
+    # prepare replacement of executor hosts
+    - executor1.apimon.eco.tsi-dev.otc-service.com
+    - executor3.apimon.eco.tsi-dev.otc-service.com
+    - executor4.apimon.eco.tsi-dev.otc-service.com


### PR DESCRIPTION
We need to replace executor hosts. One of them is not provisionable
anymore due to eol of centos8. Disable them while we prepare
replacement.
