### PR TITLE
Changing epmon limit to 120seconds on SwissCLoud

### DIFF
--- a/inventory/service/group_vars/apimon.yaml
+++ b/inventory/service/group_vars/apimon.yaml
@@ -266,7 +266,7 @@ apimon_instances:
             epmon_swift, epmon_sdrs, epmon_rds, epmon_smn,
             epmon_rest] | combine }}"
     # Do endpoints check once per minute only
-    epmon_interval: 60
+    epmon_interval: 120
 
     # Test projects
     test_projects:


### PR DESCRIPTION
Due to performance issues on SwissCloud the limit will be changed to 120secs instead of 60 to observe the performance impact on overall service response latencies.