### PR TITLE
Temp disable ZK vm installation tasks

### DIFF
--- a/playbooks/service-zookeeper.yaml
+++ b/playbooks/service-zookeeper.yaml
@@ -1,33 +1,33 @@
-# Ensure x509 certificates exists on the bridge
-- hosts: "bridge.eco.tsi-dev.otc-service.com:!disabled"
-  become: true
-  tasks:
-    - include_role:
-        name: "x509_cert"
-        tasks_from: cert.yaml
-      vars:
-        x509_common_name: "{{ host }}"
-        x509_alt_name: "IP:{{ hostvars[host].ansible_host }}"
-        x509_private_key_format: "pkcs8"
-      loop: "{{ groups['zookeeper'] }}"
-      loop_control:
-        loop_var: "host"
-
-# TODO: Manage DNS
-# - forward and reverse resolution should work properly so that cert verification passes
-
-# Provision ZK host passing certificates from bridge
-- hosts: "zookeeper:!disabled"
-  become: true
-  name: "Base: configure zookeeper instances"
-  vars:
-    ssl_ca_path: "/etc/ssl/ca/ca.pem"
-    ssl_cert_path: "/etc/ssl/certs/{{ inventory_hostname }}.pem"
-    ssl_key_path: "/etc/ssl/keys/{{ inventory_hostname }}.pem"
-  roles:
-    # Group should be responsible for defining open ports
-    - firewalld
-    - zookeeper
+## Ensure x509 certificates exists on the bridge
+#- hosts: "bridge.eco.tsi-dev.otc-service.com:!disabled"
+#  become: true
+#  tasks:
+#    - include_role:
+#        name: "x509_cert"
+#        tasks_from: cert.yaml
+#      vars:
+#        x509_common_name: "{{ host }}"
+#        x509_alt_name: "IP:{{ hostvars[host].ansible_host }}"
+#        x509_private_key_format: "pkcs8"
+#      loop: "{{ groups['zookeeper'] }}"
+#      loop_control:
+#        loop_var: "host"
+#
+## TODO: Manage DNS
+## - forward and reverse resolution should work properly so that cert verification passes
+#
+## Provision ZK host passing certificates from bridge
+#- hosts: "zookeeper:!disabled"
+#  become: true
+#  name: "Base: configure zookeeper instances"
+#  vars:
+#    ssl_ca_path: "/etc/ssl/ca/ca.pem"
+#    ssl_cert_path: "/etc/ssl/certs/{{ inventory_hostname }}.pem"
+#    ssl_key_path: "/etc/ssl/keys/{{ inventory_hostname }}.pem"
+#  roles:
+#    # Group should be responsible for defining open ports
+#    - firewalld
+#    - zookeeper
 
 # Deploy zookeeper on K8S
 - hosts: "k8s-controller:!disabled"

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -23,7 +23,7 @@
         - system-config-run-grafana
         - system-config-run-proxy
         - system-config-run-vault
-        - system-config-run-zookeeper
+        # - system-config-run-zookeeper
         - system-config-build-image-zookeeper-statsd
         - system-config-build-image-graphite-statsd
         - system-config-build-image-haproxy-statsd
@@ -43,7 +43,7 @@
         - system-config-run-grafana
         - system-config-run-proxy
         - system-config-run-vault
-        - system-config-run-zookeeper
+        # - system-config-run-zookeeper
         - system-config-upload-image-zookeeper-statsd
         - system-config-upload-image-graphite-statsd
         - system-config-upload-image-haproxy-statsd


### PR DESCRIPTION
currently we do not have ZK on VMs. Empty host list is causing in some
areas issues with inventory plugins. For now disable ZK installation on
VMs and exclude testing jobs until further notice.
