### PR TITLE
set graphite.eco storage-schemas properly

### DIFF
--- a/inventory/service/host_vars/graphite1.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/graphite1.eco.tsi-dev.otc-service.com.yaml
@@ -5,8 +5,13 @@ graphite_storage_schemas: |
   pattern = ^stats\.*\.zuul\.*
   retentions = 60:90d
 
-graphite_retention_stats: "60s:1d,5m:30d,10m:3m"
-graphite_default_stats: "60s:1d,5m:30d,10m:3m"
+  ["carbon"]
+  pattern = ^carbon\.*
+  retentions = 60:90d
+
+  ["default"]
+  pattern = .*
+  retentions = 60s:1d,5m:30d,10m:3m
 
 ssl_certs:
   graphite1-infra:


### PR DESCRIPTION
If we set storage-schemas for graphite it is expected we set full schema
definition and not only some part of it. Add missing parts now.
