### PR TITLE
fix final typo in graphite storage schema definition

### DIFF
--- a/inventory/service/host_vars/graphite1.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/graphite1.eco.tsi-dev.otc-service.com.yaml
@@ -11,7 +11,7 @@ graphite_storage_schemas: |
 
   ["default"]
   pattern = .*
-  retentions = 60s:1d,5m:30d,10m:3m
+  retentions = 60s:1d,5m:30d,10m:90d
 
 ssl_certs:
   graphite1-infra:


### PR DESCRIPTION
lower precision must be longer then higher precision (3m is 3 minutes, and not 3 months)