### PR TITLE
Make Zookeeper@k8 available outside

### DIFF
--- a/playbooks/roles/zookeeper/tasks/k8s.yaml
+++ b/playbooks/roles/zookeeper/tasks/k8s.yaml
@@ -132,7 +132,6 @@
           name: client
           targetPort: client
           protocol: TCP
-        clusterIP: None
         selector:
           app: zookeeper
 


### PR DESCRIPTION
We might want to access ZK using cluster address (i.e. by zuul client
not running in the cluster to make data backup). Do not introduce
ingress, but at least make cluster IP available.
