### PR TITLE
Enable proxy support in vault

### DIFF
--- a/inventory/service/host_vars/vault1.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/vault1.eco.tsi-dev.otc-service.com.yaml
@@ -12,4 +12,7 @@ ssl_certs:
     - "vault1.eco.tsi-dev.otc-service.com"
 vault_cert: "vault"
 
+vault_proxy_protocol_behavior: "allow_authorized"
+vault_proxy_protocol_authorized_addrs: "192.168.110.151,192.168.110.160"
+
 firewalld_extra_ports_enable: ['8200/tcp', '8201/tcp']

--- a/inventory/service/host_vars/vault2.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/vault2.eco.tsi-dev.otc-service.com.yaml
@@ -12,4 +12,7 @@ ssl_certs:
     - "vault2.eco.tsi-dev.otc-service.com"
 vault_cert: "vault"
 
+vault_proxy_protocol_behavior: "allow_authorized"
+vault_proxy_protocol_authorized_addrs: "192.168.110.151,192.168.110.160"
+
 firewalld_extra_ports_enable: ['8200/tcp', '8201/tcp']

--- a/inventory/service/host_vars/vault3.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/vault3.eco.tsi-dev.otc-service.com.yaml
@@ -12,4 +12,7 @@ ssl_certs:
     - "vault3.eco.tsi-dev.otc-service.com"
 vault_cert: "vault"
 
+vault_proxy_protocol_behavior: "allow_authorized"
+vault_proxy_protocol_authorized_addrs: "192.168.110.151,192.168.110.160"
+
 firewalld_extra_ports_enable: ['8200/tcp', '8201/tcp']

--- a/playbooks/roles/hashivault/templates/vault.hcl.j2
+++ b/playbooks/roles/hashivault/templates/vault.hcl.j2
@@ -19,6 +19,12 @@ listener "tcp" {
   address       = "0.0.0.0:8200"
   tls_cert_file = "/etc/ssl/{{ inventory_hostname }}/vault/vault-fullchain.crt"
   tls_key_file  = "/etc/ssl/{{ inventory_hostname }}/vault/vault.pem"
+{%- if vault_proxy_protocol_behavior is defined -%}
+  proxy_protocol_behavior = "{{ vault_proxy_protocol_behavior }}"
+{%- endif %}
+{%- if vault_proxy_protocol_authorized_addrs is defined -%}
+  proxy_protocol_authorized_addrs = "{{ vault_proxy_protocol_authorized_addrs }}"
+{%- endif %}
 }
 
 {% if vault_seal_transit_address is defined %}


### PR DESCRIPTION
Follow the
https://support.hashicorp.com/hc/en-us/articles/115015659767-PROXY-Protocol-Support
and authorize our haproxy instances in vault config to hopefully
properly log real client ip address instead of proxy IP.
