### PR TITLE
ensure clientIP for vault is shown in L7 LB

### DIFF
--- a/inventory/service/host_vars/vault1.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/vault1.eco.tsi-dev.otc-service.com.yaml
@@ -14,5 +14,6 @@ vault_cert: "vault"
 
 vault_proxy_protocol_behavior: "allow_authorized"
 vault_proxy_protocol_authorized_addrs: "192.168.110.151,192.168.110.160"
+vault_x_forwarded_for_addrs: "192.168.110.151,192.168.110.160"
 
 firewalld_extra_ports_enable: ['8200/tcp', '8201/tcp']

--- a/inventory/service/host_vars/vault2.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/vault2.eco.tsi-dev.otc-service.com.yaml
@@ -14,5 +14,6 @@ vault_cert: "vault"
 
 vault_proxy_protocol_behavior: "allow_authorized"
 vault_proxy_protocol_authorized_addrs: "192.168.110.151,192.168.110.160"
+vault_x_forwarded_for_addrs: "192.168.110.151,192.168.110.160"
 
 firewalld_extra_ports_enable: ['8200/tcp', '8201/tcp']

--- a/inventory/service/host_vars/vault3.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/vault3.eco.tsi-dev.otc-service.com.yaml
@@ -14,5 +14,6 @@ vault_cert: "vault"
 
 vault_proxy_protocol_behavior: "allow_authorized"
 vault_proxy_protocol_authorized_addrs: "192.168.110.151,192.168.110.160"
+vault_x_forwarded_for_addrs: "192.168.110.151,192.168.110.160"
 
 firewalld_extra_ports_enable: ['8200/tcp', '8201/tcp']

--- a/playbooks/roles/hashivault/templates/vault.hcl.j2
+++ b/playbooks/roles/hashivault/templates/vault.hcl.j2
@@ -25,6 +25,9 @@ listener "tcp" {
 {% if vault_proxy_protocol_authorized_addrs is defined %}
   proxy_protocol_authorized_addrs = "{{ vault_proxy_protocol_authorized_addrs }}"
 {% endif %}
+{% if vault_x_forwarded_for_authorized_addrs is defined %}
+  x_forwarded_for_authorized_addrs = "{{ vault_x_forwarded_for_authorized_addrs }}"
+{% endif %}
 }
 
 {% if vault_seal_transit_address is defined %}


### PR DESCRIPTION
In the L7 load balancing mode (i.e. behind haproxy with http protocol) we use not the proxy protocol, but X_Forwarded_For headers. Vault is having special config vars for this also.
