### PR TITLE
Attach /var/lib/containers in nodepool-builder

### DIFF
--- a/playbooks/roles/zuul_k8s/tasks/nodepool.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/nodepool.yaml
@@ -269,6 +269,9 @@
                     mountPath: "/dev"
                   - name: "nodepool-images-dir"
                     mountPath: "/opt/nodepool/images"
+                  # Podman need non-overlayfs
+                  - name: "nodepool-containers"
+                    mountPath: "/var/lib/containers"
                   - name: "zuul-config-data"
                     mountPath: "/data"
                   - name: "dib-tmp"
@@ -333,6 +336,8 @@
               - name: "nodepool-data-volume"
                 emptyDir: {}
               - name: "nodepool-logs"
+                emptyDir: {}
+              - name: "nodepool-containers"
                 emptyDir: {}
               - name: "zuul-config"
                 emptyDir: {}


### PR DESCRIPTION
Some OS in dib rely on podman, which fails when it does not have real FS
(https://opendev.org/opendev/system-config/src/branch/master/playbooks/roles/nodepool-builder/templates/docker-compose.yaml.j2)
Try to do same and add emptyDir.
