### PR TITLE
Update zuul nodepool

### DIFF
--- a/inventory/service/group_vars/zuul.yaml
+++ b/inventory/service/group_vars/zuul.yaml
@@ -1,23 +1,25 @@
+zuul_main_vars:
+  zookeeper_instance_group: "zuul-zookeeper"
+  gearman_server: "zuul-scheduler-main"
+  graphite_host: "192.168.14.241"
+  statsd_host: "zuul-statsd-main"
+  config_repo: "https://github.com/opentelekomcloud-infra/zuul-config.git"
+  web_domain: "zuul.otc-service.com"
+  nodepool_version_tag: "post5.0.0"
+  zuul_version_tag: "5.2.2"
+  zuul_connections:
+    - name: "github"
+      driver: "github"
+    - name: "gitlab"
+      driver: "gitlab"
+      canonical_hostname: "gitlab"
+    - name: "opendev"
+      driver: "git"
+      baseurl: "https://opendev.org"
+  vault_image: "vault:1.10.0"
+
 zuul_instances:
-  main:
-    zookeeper_instance_group: "zuul-zookeeper"
-    gearman_server: "zuul-scheduler-main"
-    graphite_host: "192.168.14.241"
-    statsd_host: "zuul-statsd-main"
-    config_repo: "https://github.com/opentelekomcloud-infra/zuul-config.git"
-    web_domain: "zuul.otc-service.com"
-    nodepool_version_tag: "5.0.0"
-    zuul_version_tag: "5.2.2"
-    zuul_connections:
-      - name: "github"
-        driver: "github"
-      - name: "gitlab"
-        driver: "gitlab"
-        canonical_hostname: "gitlab"
-      - name: "opendev"
-        driver: "git"
-        baseurl: "https://opendev.org"
-    vault_image: "vault:1.10.0"
+  main: "{{ zuul_main_vars }}"
 
 zuul_k8s_instances:
   - zuul_instance: "main"


### PR DESCRIPTION
since nodepool is still not having release use current latest as
post5.0.0. This is required to get a newer diskimage-builder with some
important fixes.
