### PR TITLE
Skip deploy jobs for zuul inventory change

### DIFF
--- a/zuul.d/infra-prod.yaml
+++ b/zuul.d/infra-prod.yaml
@@ -81,6 +81,8 @@
     parent: infra-prod-playbook
     description: Base job for most service playbooks.
     abstract: true
+    irrelevant-files:
+      - inventory/service/group_vars/zuul.yaml
 
 - job:
     name: infra-prod-service-bridge


### PR DESCRIPTION
When we modify zuul inventory there is no need to run all other
playbooks. While our inventories are still tightly coupled we can skip
it by placing zuul inv file to irrelevant-files of the base job.
