### PR TITLE
Make zuul instance counts configurable

### DIFF
--- a/inventory/service/group_vars/zuul.yaml
+++ b/inventory/service/group_vars/zuul.yaml
@@ -1,6 +1,5 @@
 zuul_main_vars:
   zookeeper_instance_group: "zuul-zookeeper"
-  gearman_server: "zuul-scheduler-main"
   graphite_host: "192.168.14.241"
   statsd_host: "zuul-statsd-main"
   config_repo: "https://github.com/opentelekomcloud-infra/zuul-config.git"
@@ -19,7 +18,22 @@ zuul_main_vars:
   vault_image: "vault:1.10.0"
 
 zuul_instances:
-  main: "{{ zuul_main_vars }}"
+  main:
+    zookeeper_instance_group: "{{ zuul_main_vars.zookeeper_instance_group }}"
+    graphite_host: "{{ zuul_main_var.graphite_host }}"
+    statsd_host: "{{ zuul_main_var.statsd_host }}"
+    config_repo: "{{ zuul_main_var.config_repo }}"
+    web_domain: "{{ zuul_main_var.web_domain }}"
+    nodepool_version_tag: "{{ zuul_main_var.nodepool_version_tag }}"
+    zuul_version_tag: "{{ zuul_main_var.zuul_version_tag }}"
+    zuul_connections: "{{ zuul_main_var.zuul_connections }}"
+    vault_image: "{{ zuul_main_var.vault_image }}"
+    zuul_web_instances_count: 2
+    zuul_scheduler_instances_count: 1
+    zuul_merger_instances_count: 1
+    zuul_executor_instances_count: 2
+    nodepool_launcher_instances_count: 1
+    nodepool_builder_instances_count: 1
 
 zuul_k8s_instances:
   - zuul_instance: "main"

--- a/playbooks/roles/zuul_k8s/tasks/nodepool.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/nodepool.yaml
@@ -36,7 +36,7 @@
           app.kubernetes.io/instance: "{{ instance }}"
           app.kubernetes.io/managed-by: "system-config"
       spec:
-        replicas: 1
+        replicas: "{{ zuul.nodepool_launcher_instances_count | default(1) }}"
         selector:
           matchLabels:
             app.kubernetes.io/app: "zuul"
@@ -196,7 +196,7 @@
           app.kubernetes.io/instance: "{{ instance }}"
           app.kubernetes.io/managed-by: "system-config"
       spec:
-        replicas: 1
+        replicas: "{{ zuul.nodepool_builder_instances_count | default(1) }}"
         serviceName: "nodepool-builder"
         selector:
           matchLabels:

--- a/playbooks/roles/zuul_k8s/tasks/zuul-executor.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul-executor.yaml
@@ -35,10 +35,10 @@
           app.kubernetes.io/managed-by: "system-config"
       spec:
         ports:
-        - name: "logs"
-          port: 7900
-          protocol: "TCP"
-          targetPort: 7900
+          - name: "logs"
+            port: 7900
+            protocol: "TCP"
+            targetPort: 7900
         selector:
           app.kubernetes.io/app: "zuul"
           app.kubernetes.io/component: "zuul-executor"
@@ -61,7 +61,7 @@
           app.kubernetes.io/instance: "{{ instance }}"
           app.kubernetes.io/managed-by: "system-config"
       spec:
-        replicas: 2
+        replicas: "{{ zuul.zuul_executor_instances_count | default(2) }}"
         selector:
           matchLabels:
             app.kubernetes.io/app: "zuul"
@@ -228,6 +228,6 @@
                 projected:
                   defaultMode: 420
                   sources:
-                  - serviceAccountToken:
-                      expirationSeconds: 7200
-                      path: "vault-token"
+                    - serviceAccountToken:
+                        expirationSeconds: 7200
+                        path: "vault-token"

--- a/playbooks/roles/zuul_k8s/tasks/zuul-merger.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul-merger.yaml
@@ -15,7 +15,7 @@
           app.kubernetes.io/instance: "{{ instance }}"
           app.kubernetes.io/managed-by: "system-config"
       spec:
-        replicas: 1
+        replicas: "{{ zuul.zuul_merger_instances_count | default(1) }}"
         podManagementPolicy: "Parallel"
         serviceName: "zuul-merger"
         selector:

--- a/playbooks/roles/zuul_k8s/tasks/zuul-scheduler.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul-scheduler.yaml
@@ -35,7 +35,7 @@
           app.kubernetes.io/instance: "{{ instance }}"
           app.kubernetes.io/managed-by: "system-config"
       spec:
-        replicas: 1
+        replicas: "{{ zuul.zuul_scheduler_instances_count | default(1) }}"
         selector:
           matchLabels:
             app.kubernetes.io/app: "zuul"
@@ -182,4 +182,4 @@
               storageClassName: "csi-nas"
               resources:
                 requests:
-                  storage: "100G"
+                  storage: "5G"

--- a/playbooks/roles/zuul_k8s/tasks/zuul-web.yaml
+++ b/playbooks/roles/zuul_k8s/tasks/zuul-web.yaml
@@ -15,7 +15,7 @@
           app.kubernetes.io/instance: "{{ instance }}"
           app.kubernetes.io/managed-by: "system-config"
       spec:
-        replicas: 2
+        replicas: "{{ zuul.zuul_web_instances_count | default(1) }}"
         selector:
           matchLabels:
             app.kubernetes.io/app: "zuul"


### PR DESCRIPTION
As a preparation for deploying backup zuul we should make cluster setup
configurable. For now only cover current cluster.
