### PR TITLE
Change default graphite retentions

### DIFF
--- a/playbooks/roles/graphite/defaults/main.yaml
+++ b/playbooks/roles/graphite/defaults/main.yaml
@@ -3,7 +3,7 @@ graphite_sync_group: graphite
 
 graphite_config_location: "/etc/graphite"
 graphite_retentions_carbon: "60:90d"
-graphite_retentions_stats: "10s:6h,1m:6d,10m:3y"
+graphite_retentions_stats: "10s:1d,1m:40d,10m:3y"
 graphite_retentions_default: "60s:1d,5m:30d,1h:1y"
 
 graphite_relay: false


### PR DESCRIPTION
We sadly need to keep 1m precision during one month. Make this now
become default.
