### PR TITLE
Fix grafana DS creds management

### DIFF
--- a/playbooks/grafana-datasources.yaml
+++ b/playbooks/grafana-datasources.yaml
@@ -1,6 +1,19 @@
 # Manage grafana datasources
 - hosts: "grafana-controller:!disabled"
   tasks:
+    - name: Get vault token
+      ansible.builtin.set_fact:
+        vault_token: "{{ lookup('community.hashi_vault.hashi_vault', 'auth/token/lookup-self') }}"
+      when: "ansible_hashi_vault_token is not defined"
+      tags: ["config"]
+
+    - name: Set vault token
+      ansible.builtin.set_fact:
+        ansible_hashi_vault_token: "{{ vault_token.id }}"
+        ansible_hashi_vault_auth_method: "token"
+      when: "vault_token is defined"
+      tags: ["config"]
+
     - include_role:
         name: "grafana"
         tasks_from: "import_ds.yaml"

--- a/playbooks/grafana-datasources.yaml
+++ b/playbooks/grafana-datasources.yaml
@@ -5,14 +5,12 @@
       ansible.builtin.set_fact:
         vault_token: "{{ lookup('community.hashi_vault.hashi_vault', 'auth/token/lookup-self') }}"
       when: "ansible_hashi_vault_token is not defined"
-      tags: ["config"]
 
     - name: Set vault token
       ansible.builtin.set_fact:
         ansible_hashi_vault_token: "{{ vault_token.id }}"
         ansible_hashi_vault_auth_method: "token"
       when: "vault_token is defined"
-      tags: ["config"]
 
     - include_role:
         name: "grafana"

--- a/playbooks/roles/grafana/tasks/import_ds.yaml
+++ b/playbooks/roles/grafana/tasks/import_ds.yaml
@@ -1,3 +1,12 @@
+- name: "Read vault data"
+  no_log: true
+  community.hashi_vault.vault_read:
+    url: "{{ ansible_hashi_vault_addr }}"
+    token: "{{ ansible_hashi_vault_token }}"
+    path: "{{ grafana_datasource_content.credentials_vault_path }}"
+  register: "ds_data"
+  when: "grafana_datasource_content.credentials_vault_path is defined"
+
 - name: "Create DataSource {{ grafana_datasource_name }}"
   community.grafana.grafana_datasource:
     state: "present"
@@ -16,7 +25,8 @@
     tls_skip_verify: "{{ grafana_datasource_content.tls_skip_verify | default(omit) }}"
 
     database: "{{ grafana_datasource_content.database | default(omit) }}"
-    user: "{{ grafana_datasource_content.user | default(omit) }}"
+    user: "{{ grafana_datasource_content.user | default(ds_data.data.data.username) | default(omit) }}"
+    password: "{{ grafana_datasource_content.password | default(ds_data.data.data.password) | default(omit) }}"
     sslmode: "{{ grafana_datasource_content.sslmode | default(omit) }}"
 
     basic_auth_user: "{{ grafana_datasource_content.basic_auth_user | default(omit) }}"
@@ -28,3 +38,40 @@
     additional_json_data: "{{ grafana_datasource_content.additional_json_data | default(omit) }}"
     additional_secure_json_data: "{{ grafana_datasource_content.additional_secure_json_data | default(omit) }}"
     enforce_secure_data: "{{ grafana_datasource_content.enforce_secure_data | default(omit) }}"
+  when: "grafana_datasource_content.ds_type != 'postgres'"
+
+# Postgre DS require password to be passed under additional_secure_json_data.
+# We can't merge it easily if we get pass from vault
+- name: "Create PG DataSource {{ grafana_datasource_name }}"
+  community.grafana.grafana_datasource:
+    state: "present"
+    name: "{{ grafana_datasource_name }}"
+
+    grafana_url: "{{ grafana_datasource_content.grafana_url }}"
+    grafana_api_key: "{{ grafana_datasource_content.grafana_api_key }}"
+
+    ds_type: "{{ grafana_datasource_content.ds_type }}"
+    ds_url: "{{ grafana_datasource_content.ds_url }}"
+    is_default: "{{ grafana_datasource_content.is_default | default(omit) }}"
+
+    tls_ca_cert: "{{ grafana_datasource_content.tls_ca_cert | default(omit) }}"
+    tls_client_cert: "{{ grafana_datasource_content.tls_client_cert | default(omit) }}"
+    tls_client_key: "{{ grafana_datasource_content.tls_client_key | default(omit) }}"
+    tls_skip_verify: "{{ grafana_datasource_content.tls_skip_verify | default(omit) }}"
+
+    database: "{{ grafana_datasource_content.database | default(omit) }}"
+    user: "{{ grafana_datasource_content.user | default(ds_data.data.data.username) | default(omit) }}"
+    password: "{{ grafana_datasource_content.password | default(ds_data.data.data.password) | default(omit) }}"
+    sslmode: "{{ grafana_datasource_content.sslmode | default(omit) }}"
+
+    basic_auth_user: "{{ grafana_datasource_content.basic_auth_user | default(omit) }}"
+    basic_auth_password: "{{ grafana_datasource_content.basic_auth_password | default(omit) }}"
+    client_cert: "{{ grafana_datasource_content.client_cert | default(omit) }}"
+    client_key: "{{ grafana_datasource_content.client_key | default(omit) }}"
+
+    access: "{{ grafana_datasource_content.access | default(omit) }}"
+    additional_json_data: "{{ grafana_datasource_content.additional_json_data | default(omit) }}"
+    additional_secure_json_data:
+      password: "{{ ds_data.data.data.password | default(omit) }}"
+    enforce_secure_data: "{{ grafana_datasource_content.enforce_secure_data | default(omit) }}"
+  when: "grafana_datasource_content.ds_type == 'postgres'"


### PR DESCRIPTION
When we want to get Grafana datasource credentials from vault we were
relying on vault lookup plugins in the inventory. While it is good on
its own it causes getting new vars every time inventory gets evaluated.
In addition if we are not accurate we get user and password not even
matching together.
Instead let us read creds from vault if vault_path is set for the DS.
