### PR TITLE
Fix docs-int template

### DIFF
--- a/playbooks/templates/docs_hosting/nginx-internal.conf.j2
+++ b/playbooks/templates/docs_hosting/nginx-internal.conf.j2
@@ -30,7 +30,7 @@ server {
   }
 
   location / {
-    set $container 'docsportal';
+    set $container 'docs';
     set $index_uri '/index.html';
 
     if ($request_uri ~* '/releasenotes(/?)$') {
@@ -70,7 +70,7 @@ server {
     }
 
     # NOTE: we are behind swift-proxy, so redirect without account
-    proxy_pass https://backend/$container$index_uri;
+    proxy_pass http://backend/$container$index_uri;
     # If we get 30x back from backend - rewrite it again to something we would understand
     proxy_redirect ~*/v1/AUTH_{{ document_hosting.swift_projectid }}/(.*)$ https://{{ document_hosting.server_name }}/$1;
     # proxy_cache staticcache;

--- a/playbooks/templates/docs_hosting/nginx-internal.conf.j2
+++ b/playbooks/templates/docs_hosting/nginx-internal.conf.j2
@@ -30,7 +30,7 @@ server {
   }
 
   location / {
-    set $container 'docs';
+    set $container 'docsportal';
     set $index_uri '/index.html';
 
     if ($request_uri ~* '/releasenotes(/?)$') {


### PR DESCRIPTION
- set back to http for backend
- temporarily set default container to docs from docsportal unless we
  create one (otherwise ready checks fail)
