### PR TITLE
Replaced include to include_tasks

### DIFF
--- a/playbooks/roles/cloud_cce/tasks/main.yaml
+++ b/playbooks/roles/cloud_cce/tasks/main.yaml
@@ -12,10 +12,10 @@
   register: "cloud_token"
   when: "clouds[cloud].vault_path is defined"
 
-- include: "provision.yaml"
+- include_tasks: "provision.yaml"
   when: "state != 'absent'"
 
-- include: "destroy.yaml"
+- include_tasks: "destroy.yaml"
   when: "state == 'absent'"
 
 - name: "Revoke lease in vault and delete user from cloud"

--- a/playbooks/roles/cloud_host/tasks/main.yaml
+++ b/playbooks/roles/cloud_host/tasks/main.yaml
@@ -12,10 +12,10 @@
   register: "cloud_token"
   when: "clouds[cloud].vault_path is defined"
 
-- include: "provision.yaml"
+- include_tasks: "provision.yaml"
   when: "state != 'absent'"
 
-- include: "destroy.yaml"
+- include_tasks: "destroy.yaml"
   when: "state == 'absent'"
 
 - name: "Revoke lease in vault and delete user from cloud"

--- a/playbooks/roles/cloud_natgw/tasks/main.yaml
+++ b/playbooks/roles/cloud_natgw/tasks/main.yaml
@@ -13,11 +13,11 @@
   when: "clouds[cloud].vault_path is defined"
 
 # Create
-- include: "provision.yaml"
+- include_tasks: "provision.yaml"
   when: "state != 'absent'"
 
 # Remove
-- include: "destroy.yaml"
+- include_tasks: "destroy.yaml"
   when: "state == 'absent'"
 
 - name: "Revoke lease in vault and delete user from cloud"

--- a/playbooks/roles/cloud_net/tasks/destroy.yaml
+++ b/playbooks/roles/cloud_net/tasks/destroy.yaml
@@ -5,7 +5,7 @@
     name: "{{ net.router }}"
     state: "{{ state }}"
 
-- include: "destroy_net.yaml"
+- include_tasks: "destroy_net.yaml"
   loop: "{{ net.nets }}"
   loop_control:
     loop_var: "network"

--- a/playbooks/roles/cloud_net/tasks/main.yaml
+++ b/playbooks/roles/cloud_net/tasks/main.yaml
@@ -13,11 +13,11 @@
   when: "clouds[cloud].vault_path is defined"
 
 # Create
-- include: "provision.yaml"
+- include_tasks: "provision.yaml"
   when: "state != 'absent'"
 
 # Remove
-- include: "destroy.yaml"
+- include_tasks: "destroy.yaml"
   when: "state == 'absent'"
 
 - name: "Revoke lease in vault and delete user from cloud"

--- a/playbooks/roles/cloud_net/tasks/net.yaml
+++ b/playbooks/roles/cloud_net/tasks/net.yaml
@@ -6,7 +6,7 @@
     state: "{{ state }}"
   register: "cloud_net_network"
 
-- include: "subnet.yaml"
+- include_tasks: "subnet.yaml"
   loop: "{{ network.subnets }}"
   loop_control:
     loop_var: "subnet"

--- a/playbooks/roles/cloud_net/tasks/provision.yaml
+++ b/playbooks/roles/cloud_net/tasks/provision.yaml
@@ -1,6 +1,6 @@
 ---
 # Create
-- include: "net.yaml"
+- include_tasks: "net.yaml"
   loop: "{{ net.nets }}"
   loop_control:
     loop_var: "network"

--- a/playbooks/roles/cloud_rds/tasks/main.yaml
+++ b/playbooks/roles/cloud_rds/tasks/main.yaml
@@ -12,10 +12,10 @@
   register: "cloud_token"
   when: "clouds[cloud].vault_path is defined"
 
-- include: "provision.yaml"
+- include_tasks: "provision.yaml"
   when: "state != 'absent'"
 
-- include: "destroy.yaml"
+- include_tasks: "destroy.yaml"
   when: "state == 'absent'"
 
 - name: "Revoke lease in vault and delete user from cloud"

--- a/playbooks/roles/cloud_sg/tasks/main.yaml
+++ b/playbooks/roles/cloud_sg/tasks/main.yaml
@@ -12,10 +12,10 @@
   register: "cloud_token"
   when: "clouds[cloud].vault_path is defined"
 
-- include: "provision.yaml"
+- include_tasks: "provision.yaml"
   when: "state != 'absent'"
 
-- include: "destroy.yaml"
+- include_tasks: "destroy.yaml"
   when: "state == 'absent'"
 
 - name: "Revoke lease in vault and delete user from cloud"

--- a/playbooks/roles/cloud_vpcp/tasks/main.yaml
+++ b/playbooks/roles/cloud_vpcp/tasks/main.yaml
@@ -25,10 +25,10 @@
   register: "remote_cloud_token"
   when: "clouds[remote_cloud].vault_path is defined"
 
-- include: "provision.yaml"
+- include_tasks: "provision.yaml"
   when: "state != 'absent'"
 
-- include: "destroy.yaml"
+- include_tasks: "destroy.yaml"
   when: "state == 'absent'"
 
 - name: "Revoke lease in vault and delete user from cloud"

--- a/playbooks/roles/install-docker/tasks/main.yaml
+++ b/playbooks/roles/install-docker/tasks/main.yaml
@@ -5,11 +5,11 @@
     path: /etc/docker
 
 - name: Install docker-ce from upstream
-  include: upstream.yaml
+  include_tasks: upstream.yaml
   when: use_upstream_docker|bool
 
 - name: Install docker-engine from distro
-  include: distro.yaml
+  include_tasks: distro.yaml
   when: not use_upstream_docker|bool
 
 - name: reset ssh connection to pick up docker group


### PR DESCRIPTION
Minor fix to avoid deprecation message

```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```