### PR TITLE
rename branch of the ansible-collection-cloud

### DIFF
--- a/zuul.d/infra-prod.yaml
+++ b/zuul.d/infra-prod.yaml
@@ -44,7 +44,7 @@
       - name: github.com/stackmon/ansible-collection-apimon
         override-checkout: main
       - name: github.com/opentelekomcloud/ansible-collection-cloud
-        override-checkout: master
+        override-checkout: main
       - name: github.com/opentelekomcloud/ansible-collection-gitcontrol
         override-checkout: main
       - name: opendev.org/openstack/ansible-collections-openstack

--- a/zuul.d/system-config-run.yaml
+++ b/zuul.d/system-config-run.yaml
@@ -19,7 +19,7 @@
         '/var/log/containers': logs
     required-projects:
       - name: github.com/opentelekomcloud/ansible-collection-cloud
-        override-checkout: master
+        override-checkout: main
       - name: github.com/stackmon/ansible-collection-apimon
         override-checkout: main
       - name: github.com/opentelekomcloud/ansible-collection-gitcontrol


### PR DESCRIPTION
default branch of the ansible-colleciton-cloud has been renamed to "main"