### PR TITLE
Workaround gitea bug with showmore button

### DIFF
--- a/inventory/service/group_vars/gitea.yaml
+++ b/inventory/service/group_vars/gitea.yaml
@@ -1,5 +1,5 @@
-gitea_version: "1.17.4"
-gitea_checksum: "sha256:a720c1e87748e4fc5e37f4079ad0f8369d3c6d63e274856eb04201857c98ca2b"
+gitea_version: "1.18.0"
+gitea_checksum: "sha256:b45b715d519a97086208c6b42528d291dd1c4dfdf40321dc940030e1cf3de6e6"
 
 gitea_domain: "gitea.eco.tsi-dev.otc-service.com"
 gitea_app_name: "Open Telekom Cloud: git"

--- a/playbooks/roles/gitea/templates/app.ini.j2
+++ b/playbooks/roles/gitea/templates/app.ini.j2
@@ -139,7 +139,9 @@ ENABLE_SSH_LOG = true
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [git]
 MAX_GIT_DIFF_LINES = 100
-MAX_GIT_DIFF_FILES = 50
+# TODO(gtema): This is a workaround for gitea bug
+# turn back to 50 as soon as fix is released
+MAX_GIT_DIFF_FILES = 500
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [service]


### PR DESCRIPTION
sadly we are not able to rollback without downgrading DB what we are not able to do. In order to at least somehow let people work increase default amount of files in diff to 500 files.