### PR TITLE
disable listing users in gitea without auth

### DIFF
--- a/playbooks/roles/gitea/templates/app.ini.j2
+++ b/playbooks/roles/gitea/templates/app.ini.j2
@@ -163,6 +163,15 @@ SHOW_REGISTRATION_BUTTON = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[service.explore]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+DISABLE_USERS_PAGE = true
+;; require signing is set to true but is not available by the above option
+REQUIRE_SIGNIN_VIEW = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Other Settings
 ;;
 ;; Uncomment the [section.header] if you wish to
@@ -265,6 +274,7 @@ DEFAULT_MERGE_STYLE = squash
 [ui]
 EXPLORE_PAGING_NUM = 20
 ISSUE_PAGING_NUM = 20
+SHOW_USER_EMAIL = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
We should disable exposing our users to the outside world (google)

Config options uses as described in https://docs.gitea.io/en-us/config-cheat-sheet