### PR TITLE
Add a redirect for broken link

### DIFF
--- a/playbooks/templates/docs_hosting/redirect_maps/redirect-elastic-cloud-server.map
+++ b/playbooks/templates/docs_hosting/redirect_maps/redirect-elastic-cloud-server.map
@@ -538,3 +538,5 @@
   /en-us/usermanual/ecs/en-us_topic_0000001143214829.html /elastic-cloud-server/umn/troubleshooting/how_do_i_configure_atop_and_kdump_on_linux_ecss_for_performance_analysis.html;
   /en-us/usermanual/ecs/en-us_topic_0094801708.html /elastic-cloud-server/umn/troubleshooting/what_can_i_do_if_switching_from_a_non-root_user_to_user_root_times_out.html;
   /en-us/usermanual/ecs/en-us_topic_0107412162.html /elastic-cloud-server/umn/troubleshooting/what_should_i_do_if_error_command_gcc_failed_with_exit_status_1_occurs_during_pip-based_software_installation.html;
+
+  /usermanual/ecs/en-us_topic_0014250631.html /elastic-cloud-server/umn/passwords_and_key_pairs/key_pairs/index.html;


### PR DESCRIPTION
https://github.com/opentelekomcloud-docs/docsportal/issues/59

Since the link on it's own is broken we redirect rewrite it to general
key pair page.
