### PR TITLE
Move map statement outside of jinja if

### DIFF
--- a/playbooks/templates/docs_hosting/nginx-beta.conf.j2
+++ b/playbooks/templates/docs_hosting/nginx-beta.conf.j2
@@ -43,12 +43,13 @@ upstream backend {
   server {{ document_hosting.swift_server }}:443;
 }
 
-{% if document_hosting.redirect_maps is defined and document_hosting.redirect_maps %}
 map_hash_max_size 2048;
 map_hash_bucket_size 2048;
 map $request_uri $request_uri_path {
   "~^(?P<path>[^?]*)(\?.*)?$"  $path;
 }
+
+{% if document_hosting.redirect_maps is defined and document_hosting.redirect_maps %}
 map $request_uri_path $new_uri {
   default "";
 {% for map in document_hosting.redirect_maps.keys() %}

--- a/playbooks/templates/docs_hosting/nginx-public.conf.j2
+++ b/playbooks/templates/docs_hosting/nginx-public.conf.j2
@@ -43,12 +43,13 @@ upstream backend {
   server {{ document_hosting.swift_server }}:443;
 }
 
-{% if document_hosting.redirect_maps is defined and document_hosting.redirect_maps %}
 map_hash_max_size 2048;
 map_hash_bucket_size 2048;
 map $request_uri $request_uri_path {
   "~^(?P<path>[^?]*)(\?.*)?$"  $path;
 }
+
+{% if document_hosting.redirect_maps is defined and document_hosting.redirect_maps %}
 map $request_uri_path $new_uri {
   default "";
 {% for map in document_hosting.redirect_maps.keys() %}


### PR DESCRIPTION
nginx-public template is used for "main" docs portal as well and this on
is not having any redirect maps. Since we evaluate result of this map in
a general block it makes sence to move it outside of the if.
