### PR TITLE
feat: update Zuul Kustomize app

### DIFF
--- a/kubernetes/zuul/base/kustomization.yaml
+++ b/kubernetes/zuul/base/kustomization.yaml
@@ -12,9 +12,11 @@ components:
   - ../components/nodepool-launcher
 
 configMapGenerator:
-  - name: zuul-instance-config
+  - name: "zuul-instance-config"
     literals:
       - ZUUL_CONFIG_REPO=https://gitea.eco.tsi-dev.otc-service.com/scs/zuul-config.git
+  - name: "zuul-executor-vars"
+    literals: []
 
 labels:
   - includeSelectors: true

--- a/kubernetes/zuul/components/nodepool-builder/statefulset.yaml
+++ b/kubernetes/zuul/components/nodepool-builder/statefulset.yaml
@@ -35,10 +35,10 @@ spec:
           resources:
             limits:
               cpu: "300m"
-              memory: "500Mi"
+              memory: "512Mi"
             requests:
               cpu: "100m"
-              memory: "200Mi"
+              memory: "256Mi"
 
           securityContext:
             privileged: true
@@ -71,6 +71,10 @@ spec:
 
       serviceAccountName: "zuul"
       volumes:
+        - name: "nodepool-config"
+          secret:
+            secretName: "nodepool-config"
+
         - name: "dev"
           hostPath:
             path: "/dev"
@@ -80,10 +84,6 @@ spec:
 
         - name: "dib-tmp"
           emptyDir: {}
-
-        - name: "nodepool-config"
-          secret:
-            secretName: "nodepool-config"
 
         - name: "nodepool-containers"
           emptyDir: {}

--- a/kubernetes/zuul/components/nodepool-launcher/deployment.yaml
+++ b/kubernetes/zuul/components/nodepool-launcher/deployment.yaml
@@ -12,13 +12,13 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: "zuul"
-      app.kubernetes.io/part-of: zuul
+      app.kubernetes.io/part-of: "zuul"
       app.kubernetes.io/component: "nodepool-launcher"
   template:
     metadata:
       labels:
         app.kubernetes.io/name: "zuul"
-        app.kubernetes.io/part-of: zuul
+        app.kubernetes.io/part-of: "zuul"
         app.kubernetes.io/component: "nodepool-launcher"
     spec:
       containers:
@@ -33,10 +33,10 @@ spec:
 
           resources:
             limits:
-              cpu: "300m"
+              cpu: "100m"
               memory: "500Mi"
             requests:
-              cpu: "100m"
+              cpu: "50m"
               memory: "200Mi"
 
           securityContext:

--- a/kubernetes/zuul/components/nodepool-launcher/hpa.yaml
+++ b/kubernetes/zuul/components/nodepool-launcher/hpa.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: autoscaling/v2
+kind: "HorizontalPodAutoscaler"
+metadata:
+  name: "nodepool-launcher"
+  labels:
+    app.kubernetes.io/name: "zuul"
+    app.kubernetes.io/part-of: "zuul"
+    app.kubernetes.io/component: "nodepool-launcher"
+spec:
+  scaleTargetRef:
+    kind: "Deployment"
+    name: "nodepool-launcher"
+    apiVersion: "apps/v1"
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: "Resource"
+      resource:
+        name: "cpu"
+        target:
+          type: "Utilization"
+          averageUtilization: 70

--- a/kubernetes/zuul/components/nodepool-launcher/kustomization.yaml
+++ b/kubernetes/zuul/components/nodepool-launcher/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Component
 
 resources:
   - deployment.yaml
+  - hpa.yaml

--- a/kubernetes/zuul/components/restarter/README.md
+++ b/kubernetes/zuul/components/restarter/README.md
@@ -1,0 +1,8 @@
+# Zuul restarter
+
+Sometimes credentials stored in Vault are rotated outside of Zuul. Since Zuul
+itself is not capable of reloading its general configration it is better to
+simply periodically restart certain parts of it.
+
+This component is implementing K8 ServiceAccount with role and few CronJobs
+that restart some Zuul components.

--- a/kubernetes/zuul/components/restarter/crb.yaml
+++ b/kubernetes/zuul/components/restarter/crb.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "restart-deployment"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "restart-deployment"
+subjects:
+  - kind: "ServiceAccount"
+    name: "restart-deployment"

--- a/kubernetes/zuul/components/restarter/job-restart-nodepool-launcher.yaml
+++ b/kubernetes/zuul/components/restarter/job-restart-nodepool-launcher.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "restart-nodepool-launcher"
+spec:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  schedule: '15 22 * * *'
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: "restart-deployment"
+          restartPolicy: Never
+          containers:
+            - name: "kubectl"
+              image: "bitnami/kubectl"
+              command:
+                - "bash"
+                - "-c"
+                - >-
+                  kubectl rollout restart deployment/nodepool-launcher &&
+                  kubectl rollout status deployment/nodepool-launcher

--- a/kubernetes/zuul/components/restarter/job-restart-zuul-web.yaml
+++ b/kubernetes/zuul/components/restarter/job-restart-zuul-web.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "restart-zuul-web"
+spec:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  schedule: '0 0 * * *'
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: "restart-deployment"
+          restartPolicy: Never
+          containers:
+            - name: "kubectl"
+              image: "bitnami/kubectl"
+              command:
+                - "bash"
+                - "-c"
+                - >-
+                  kubectl rollout restart deployment/zuul-web &&
+                  kubectl rollout status deployment/zuul-web

--- a/kubernetes/zuul/components/restarter/kustomization.yaml
+++ b/kubernetes/zuul/components/restarter/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - sa.yaml
+  - role.yaml
+  - crb.yaml
+  - job-restart-zuul-web.yaml
+  - job-restart-nodepool-launcher.yaml

--- a/kubernetes/zuul/components/restarter/role.yaml
+++ b/kubernetes/zuul/components/restarter/role.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "restart-deployment"
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    # resourceNames: ["test-pod"]
+    verbs: ["get", "patch", "list", "watch"]

--- a/kubernetes/zuul/components/restarter/sa.yaml
+++ b/kubernetes/zuul/components/restarter/sa.yaml
@@ -1,0 +1,5 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "restart-deployment"

--- a/kubernetes/zuul/components/zookeeper/kustomization.yaml
+++ b/kubernetes/zuul/components/zookeeper/kustomization.yaml
@@ -19,7 +19,7 @@ labels:
 images:
   - name: "zookeeper"
     newName: "quay.io/opentelekomcloud/zookeeper"
-    newTag: "3.8.0"
+    newTag: "3.8.1"
 
 resources:
   - cert.yaml

--- a/kubernetes/zuul/components/zookeeper/statefulset.yaml
+++ b/kubernetes/zuul/components/zookeeper/statefulset.yaml
@@ -40,13 +40,6 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
           image: "zookeeper"
-          resources:
-            limits:
-              cpu: "500m"
-              memory: "4Gi"
-            requests:
-              cpu: "100m"
-              memory: "1Gi"
           command:
             - "/bin/bash"
             - "-xec"
@@ -107,6 +100,14 @@ spec:
               value: "false"
             - name: ZOO_TICK_TIME
               value: "2000"
+
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "2Gi"
+            requests:
+              cpu: "20m"
+              memory: "1Gi"
 
           volumeMounts:
             - name: data

--- a/kubernetes/zuul/components/zuul-client/deployment.yaml
+++ b/kubernetes/zuul/components/zuul-client/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         # Zuul-client is a regular zuul-web image doing nothing.
         # We use it only to have completely independent pod serving as
         # zuul client for i.e. maintenance.
-        - name: "zuul-client"
+        - name: "zuul"
           image: "zuul/zuul-web"
           command:
             - "sh"
@@ -34,10 +34,10 @@ spec:
           resources:
             limits:
               cpu: "50m"
-              memory: "200Mi"
+              memory: "128Mi"
             requests:
-              cpu: "20m"
-              memory: "100Mi"
+              cpu: "10m"
+              memory: "32Mi"
 
           securityContext:
             runAsUser: 10001

--- a/kubernetes/zuul/components/zuul-config/deployment.yaml
+++ b/kubernetes/zuul/components/zuul-config/deployment.yaml
@@ -44,11 +44,11 @@ spec:
           image: "zuul/nodepool-builder"
           resources:
             limits:
-              cpu: "100m"
-              memory: "128Mi"
+              cpu: "50m"
+              memory: "64Mi"
             requests:
               cpu: "10m"
-              memory: "64Mi"
+              memory: "5Mi"
 
           volumeMounts:
             - name: "zuul-config-data"
@@ -62,3 +62,5 @@ spec:
         - name: "zuul-config-data"
           persistentVolumeClaim:
             claimName: "zuul-config"
+
+  revisionHistoryLimit: 2

--- a/kubernetes/zuul/components/zuul-executor/statefulset.yaml
+++ b/kubernetes/zuul/components/zuul-executor/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
 
       containers:
-        - name: "executor"
+        - name: "zuul"
           image: "zuul/zuul-executor"
           args: ["/usr/local/bin/zuul-executor", "-f", "-d"]
           env:
@@ -58,18 +58,35 @@ spec:
             - containerPort: 7900
               name: "logs"
               protocol: "TCP"
+            - containerPort: 9091
+              name: "prometheus"
+              protocol: "TCP"
+
+                #          readinessProbe:
+                #            httpGet:
+                #              path: "/health/ready"
+                #              port: "prometheus"
+                #            failureThreshold: 20
+                #            periodSeconds: 10
+                #          livenessProbe:
+                #            httpGet:
+                #              path: "/health/live"
+                #              port: "prometheus"
+                #            initialDelaySeconds: 120
+                #            failureThreshold: 10
+                #            periodSeconds: 5
+                #            timeoutSeconds: 5
 
           resources:
             limits:
-              cpu: "2"
+              cpu: "2000m"
               memory: "8G"
             requests:
-              cpu: "1"
+              cpu: "500m"
               memory: "1G"
 
           securityContext:
             privileged: true
-
 
           volumeMounts:
             - name: "zuul-config"
@@ -82,6 +99,11 @@ spec:
               mountPath: "/etc/zuul-config"
             - name: "zuul-var"
               mountPath: "/var/lib/zuul"
+            - name: "zuul-vars"
+              mountPath: "/var/run/zuul/vars"
+            - name: "zuul-trusted-ro"
+              mountPath: "/var/run/zuul/trusted-ro"
+              readOnly: true
 
       serviceAccountName: "zuul"
       terminationGracePeriodSeconds: 120
@@ -97,6 +119,13 @@ spec:
         - name: "zuul-config-data"
           persistentVolumeClaim:
             claimName: "zuul-config"
+
+        - name: "zuul-vars"
+          configMap:
+            name: "zuul-executor-vars"
+
+        - name: "zuul-trusted-ro"
+          emptyDir: {}
 
         - name: "zuul-var"
           emptyDir: {}

--- a/kubernetes/zuul/components/zuul-merger/deployment.yaml
+++ b/kubernetes/zuul/components/zuul-merger/deployment.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: "zuul-merger"
   labels:
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/component: "zuul-merger"
 spec:
   replicas: 1
-  serviceName: "zuul-merger"
   selector:
     matchLabels:
       app.kubernetes.io/name: "zuul"
@@ -40,17 +39,37 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
 
       containers:
-        - name: "merger"
+        - name: "zuul"
           image: "zuul/zuul-merger"
           args: ["/usr/local/bin/zuul-merger", "-f", "-d"]
+
+          ports:
+            - containerPort: 9091
+              name: "prometheus"
+              protocol: "TCP"
+
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: "prometheus"
+            failureThreshold: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/health/live"
+              port: "prometheus"
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
 
           resources:
             limits:
               cpu: "200m"
-              memory: "400Mi"
+              memory: "600Mi"
             requests:
               cpu: "50m"
-              memory: "200Mi"
+              memory: "100Mi"
 
           securityContext:
             runAsUser: 10001
@@ -85,3 +104,4 @@ spec:
 
         - name: "zuul-var"
           emptyDir: {}
+  revisionHistoryLimit: 2

--- a/kubernetes/zuul/components/zuul-merger/hpa.yaml
+++ b/kubernetes/zuul/components/zuul-merger/hpa.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: autoscaling/v2
+kind: "HorizontalPodAutoscaler"
+metadata:
+  name: "zuul-merger"
+  labels:
+    app.kubernetes.io/name: "zuul"
+    app.kubernetes.io/part-of: "zuul"
+    app.kubernetes.io/component: "zuul-merger"
+spec:
+  scaleTargetRef:
+    kind: "Deployment"
+    name: "zuul-merger"
+    apiVersion: "apps/v1"
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+    - type: "Resource"
+      resource:
+        name: "cpu"
+        target:
+          type: "Utilization"
+          averageUtilization: 70

--- a/kubernetes/zuul/components/zuul-merger/kustomization.yaml
+++ b/kubernetes/zuul/components/zuul-merger/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-  - statefulset.yaml
+  - deployment.yaml
+  - hpa.yaml

--- a/kubernetes/zuul/components/zuul-scheduler/statefulset.yaml
+++ b/kubernetes/zuul/components/zuul-scheduler/statefulset.yaml
@@ -37,9 +37,29 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
 
       containers:
-        - name: "scheduler"
+        - name: "zuul"
           image: "zuul/zuul-scheduler"
           args: ["/usr/local/bin/zuul-scheduler", "-f", "-d"]
+
+          ports:
+            - containerPort: 9091
+              name: "prometheus"
+              protocol: "TCP"
+
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: "prometheus"
+            failureThreshold: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/health/live"
+              port: "prometheus"
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
 
           resources:
             limits:

--- a/kubernetes/zuul/components/zuul-web/deployment.yaml
+++ b/kubernetes/zuul/components/zuul-web/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: "zuul-web"
     spec:
       containers:
-        - name: "web"
+        - name: "zuul"
           image: "zuul/zuul-web"
           args: ["/usr/local/bin/zuul-web", "-f", "-d"]
 
@@ -30,6 +30,24 @@ spec:
             - containerPort: 9000
               name: "web"
               protocol: "TCP"
+            - containerPort: 9091
+              name: "prometheus"
+              protocol: "TCP"
+
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: "prometheus"
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/health/live"
+              port: "prometheus"
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
 
           resources:
             limits:

--- a/kubernetes/zuul/overlays/zuul_ci/configs/site-vars.yaml
+++ b/kubernetes/zuul/overlays/zuul_ci/configs/site-vars.yaml
@@ -1,0 +1,3 @@
+---
+zuul_base_vault_token_path: /var/run/zuul/trusted-ro/zuul-base-vault-token
+zuul_vault_addr: https://vault-lb.eco.tsi-dev.otc-service.com:8200

--- a/kubernetes/zuul/overlays/zuul_ci/configs/vault-agent/executor-base-vault-agent.hcl
+++ b/kubernetes/zuul/overlays/zuul_ci/configs/vault-agent/executor-base-vault-agent.hcl
@@ -1,0 +1,29 @@
+pid_file = "/home/vault/.pid"
+
+"auto_auth" = {
+    "method" = {
+        "mount_path" = "auth/kubernetes_otcci"
+        "config" = {
+          # Here we explicitly request zuul-base role which gives access to 
+          # only certain policies
+          "role" = "zuul-base"
+        }
+        "type" = "kubernetes"
+      }
+    sink "file" {
+        config = {
+            # Write token into the file zuul executor reads
+            path = "/var/run/zuul/trusted-ro/zuul-base-vault-token"
+        }
+    }
+}
+
+cache {
+    use_auto_auth_token = true
+}
+
+# Vault agent requires at least one template or listener is present. Add a socket
+listener "unix" {
+    address = "/home/vault/vault_agent.socket"
+    tls_disable = true
+}

--- a/kubernetes/zuul/overlays/zuul_ci/crb_admin.yaml
+++ b/kubernetes/zuul/overlays/zuul_ci/crb_admin.yaml
@@ -2,11 +2,11 @@
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "ClusterRoleBinding"
 metadata:
-  name: "zuul-vault-crb"
+  name: "zuul-admin-crb"
 roleRef:
-  apiGroup: "rbac.authorization.k8s.io"
   kind: "ClusterRole"
-  name: "system:auth-delegator"
+  name: "cluster-admin"
+  apiGroup: ""
 subjects:
   - kind: "ServiceAccount"
     name: "zuul"

--- a/kubernetes/zuul/overlays/zuul_ci/kustomization.yaml
+++ b/kubernetes/zuul/overlays/zuul_ci/kustomization.yaml
@@ -6,16 +6,22 @@ components:
   - ../../components/zuul-client
   - ../../components/zuul-merger
   - ../../components/nodepool-builder
+  - ../../components/restarter
 
 configMapGenerator:
   - name: "vault-agent-config"
     files:
       - "config-zuul.hcl=configs/vault-agent/config-zuul.hcl"
       - "config-nodepool.hcl=configs/vault-agent/config-nodepool.hcl"
+      - "executor-base-vault-agent.hcl=configs/vault-agent/executor-base-vault-agent.hcl"
   - name: "zuul-instance-config"
     behavior: "replace"
     literals:
       - ZUUL_CONFIG_REPO=https://github.com/opentelekomcloud-infra/zuul-config/
+  - name: "zuul-executor-vars"
+    behavior: "replace"
+    files:
+      - "configs/site-vars.yaml"
 
 labels:
   - includeSelectors: true
@@ -49,11 +55,11 @@ images:
 
   - name: "zuul/nodepool-builder"
     newName: "quay.io/opentelekomcloud/nodepool-builder"
-    newTag: "6.2.0"
+    newTag: "8.2.0"
 
   - name: "zuul/nodepool-launcher"
     newName: "quay.io/opentelekomcloud/nodepool-launcher"
-    newTag: "6.2.0"
+    newTag: "8.2.0"
 
 patches:
   # Patch zookeeper (storage class, size and count)
@@ -81,39 +87,35 @@ patches:
         path: /spec/template/spec/volumes/0
         value:
           name: "zuul-config"
-          emptyDir: {}
-    target:
-      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (zuul-client,zuul-web)"
-      group: apps
-      version: v1
-      kind: Deployment
-
-  - path: patch-zuul.yaml
-    target:
-      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (zuul-client,zuul-web)"
-      group: apps
-      version: v1
-      kind: Deployment
-
-  - patch: |-
-      - op: replace
-        path: /spec/template/spec/volumes/0
-        value:
-          name: "zuul-config"
           emptyDir:
             medium: "Memory"
     target:
-      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (zuul-scheduler,zuul-executor,zuul-merger)"
+      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (zuul-scheduler,zuul-executor,zuul-merger,zuul-web,zuul-client)"
       group: apps
       version: v1
-      kind: StatefulSet
 
   - path: patch-zuul.yaml
     target:
-      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (zuul-scheduler,zuul-executor,zuul-merger)"
+      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (zuul-scheduler,zuul-executor,zuul-merger,zuul-web,zuul-client)"
       group: apps
       version: v1
-      kind: StatefulSet
+
+  # Patching zuul-executor count
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2
+    target:
+      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component=zuul-executor"
+      group: apps
+      version: v1
+
+  # Add zuul-executor base job vault token
+  - path: patch-zuul-executor.yaml
+    target:
+      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component=zuul-executor"
+      group: apps
+      version: v1
 
   # Patching Nodepool components (replace config and enable vault)
   - patch: |-
@@ -123,24 +125,15 @@ patches:
           name: "nodepool-config"
           emptyDir: {}
     target:
-      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (nodepool-launcher)"
+      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (nodepool-launcher,nodepool-builder)"
       group: apps
       version: v1
-      kind: Deployment
 
   - path: patch-nodepool.yaml
     target:
-      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (nodepool-launcher)"
+      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (nodepool-launcher,nodepool-builder)"
       group: apps
       version: v1
-      kind: Deployment
-
-  - path: patch-nodepool.yaml
-    target:
-      labelSelector: "app.kubernetes.io/name=zuul,app.kubernetes.io/component in (nodepool-builder)"
-      group: apps
-      version: v1
-      kind: StatefulSet
 
   # Patching web
   - patch: |-
@@ -150,7 +143,6 @@ patches:
       - op: replace
         path: /spec/rules/0/host
         value: zuul.otc-service.com
-        value: zuul
       - op: replace
         path: /metadata/annotations
         value:
@@ -159,7 +151,7 @@ patches:
         path: /spec/tls
         value:
           - hosts:
-              - zuul
+              - zuul.otc-service.com
             secretName: zuul-cert-prod
     target:
       group: networking.k8s.io
@@ -170,6 +162,7 @@ patches:
 resources:
   - ../../base
   - crb.yaml
+  - crb_admin.yaml
 
 secretGenerator:
   # Replacing general secrets to be able to trigger updates

--- a/kubernetes/zuul/overlays/zuul_ci/patch-nodepool.yaml
+++ b/kubernetes/zuul/overlays/zuul_ci/patch-nodepool.yaml
@@ -1,4 +1,5 @@
 ---
+# Adding HashiCorp Vault agent  sidecar to render nodepool configs
 apiVersion: apps/v1
 kind: not-used
 metadata:
@@ -41,10 +42,10 @@ spec:
             runAsUser: 10001
           resources:
             limits:
-              cpu: 500m
+              cpu: 100m
               memory: 128Mi
             requests:
-              cpu: 250m
+              cpu: 5m
               memory: 64Mi
           volumeMounts:
             - mountPath: "/home/vault"
@@ -87,11 +88,11 @@ spec:
             runAsUser: 10001
           resources:
             limits:
-              cpu: 500m
-              memory: 128Mi
+              cpu: "50m"
+              memory: "64Mi"
             requests:
-              cpu: 250m
-              memory: 64Mi
+              cpu: "5m"
+              memory: "32Mi"
           volumeMounts:
             - mountPath: "/home/vault"
               name: "home-init"

--- a/kubernetes/zuul/overlays/zuul_ci/patch-zuul-executor.yaml
+++ b/kubernetes/zuul/overlays/zuul_ci/patch-zuul-executor.yaml
@@ -1,0 +1,60 @@
+---
+# In order to enable access to HashiCorp Vault inside jobs it is required to
+# provide a base vault token in the executor. It is done by spinning additional
+# vault-agent sidecar container which only writes vault access token with
+# specified role (and strictly limited privileges) to the specified location,
+# from which trusted jobs can read it and further use as defined by jobs.
+apiVersion: apps/v1
+kind: not-used
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      containers:
+        - name: "vault-agent-executor-base"
+          args:
+            - vault agent -config=/vault/configs/executor-base-vault-agent.hcl
+          command:
+            - "/bin/sh"
+            - "-ec"
+          env:
+            - name: "VAULT_ADDR"
+              value: "https://vault-lb.eco.tsi-dev.otc-service.com:8200"
+            - name: "VAULT_LOG_LEVEL"
+              value: "debug"
+            - name: "VAULT_LOG_FORMAT"
+              value: "standard"
+          image: "hashicorp/vault"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            # For some weird reason we need to have content as root, otherwise
+            # zuul executor (ansible) is not able to access file
+          resources:
+            limits:
+              cpu: "50m"
+              memory: "64Mi"
+            requests:
+              cpu: "5m"
+              memory: "32Mi"
+          volumeMounts:
+            - mountPath: "/home/vault"
+              name: "home-vault-base"
+            - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+              name: "kube-api-access"
+              readOnly: true
+            - mountPath: "/vault/configs"
+              name: "vault-config"
+              readOnly: true
+            - mountPath: "/var/run/zuul/trusted-ro"
+              # since we want to populate it - no readonly
+              name: "zuul-trusted-ro"
+
+      volumes:
+        - name: "home-vault-base"
+          emptyDir:
+            medium: "Memory"

--- a/kubernetes/zuul/overlays/zuul_ci/patch-zuul.yaml
+++ b/kubernetes/zuul/overlays/zuul_ci/patch-zuul.yaml
@@ -1,4 +1,5 @@
 ---
+# Add HashiCorp Vault agent sidecars to render Zuul config
 apiVersion: apps/v1
 kind: not-used
 metadata:
@@ -6,6 +7,13 @@ metadata:
 spec:
   template:
     spec:
+      hostAliases:
+        - hostnames:
+            - git.tsi-dev.otc-service.com
+          ip: 192.168.170.142
+        - hostnames:
+            - artifacts.eco.tsi-dev.otc-service.com
+          ip: 192.168.170.129
       containers:
         - name: "vault-agent"
           args:
@@ -32,10 +40,10 @@ spec:
             runAsUser: 10001
           resources:
             limits:
-              cpu: 500m
+              cpu: 100m
               memory: 128Mi
             requests:
-              cpu: 250m
+              cpu: 5m
               memory: 64Mi
           volumeMounts:
             - mountPath: "/home/vault"
@@ -78,11 +86,11 @@ spec:
             runAsUser: 10001
           resources:
             limits:
-              cpu: 500m
-              memory: 128Mi
+              cpu: "50m"
+              memory: "64Mi"
             requests:
-              cpu: 250m
-              memory: 64Mi
+              cpu: "5m"
+              memory: "32Mi"
           volumeMounts:
             - mountPath: "/home/vault"
               name: "home-init"
@@ -117,15 +125,12 @@ spec:
                         apiVersion: "v1"
                         fieldPath: "metadata.namespace"
                       path: "namespace"
-        - emptyDir:
+        - name: "home-init"
+          emptyDir:
             medium: "Memory"
-          name: "home-init"
-        - emptyDir:
+        - name: "home-sidecar"
+          emptyDir:
             medium: "Memory"
-          name: "home-sidecar"
-            #        - emptyDir:
-            #            medium: "Memory"
-            #          name: "zuul-config"
         - name: "vault-config"
           configMap:
             name: "vault-agent-config"


### PR DESCRIPTION
in order of a switch to the new setup few issues have been identified

- missing vault base token and vars inside zuul executor
- too high requests for most components
- updated nodepool to 8.2.0
- added cronjobs to restart zuul-web and nodepool-launcher
- add nodepool-launcher hpa
- converted zuul-merger from SS to Dpl
- enabled vault un-templating for zuul-client/config
- simplified overlay kustomization patching
- fixed patchong of nodepool-launcher
- update zookeeper to 3.8.1 with few interesting bugfixes
