### PR TITLE
fix: do not try to preserve log ownership

### DIFF
--- a/playbooks/zuul/run-production-playbook-post.yaml
+++ b/playbooks/zuul/run-production-playbook-post.yaml
@@ -39,7 +39,9 @@
             src: '{{ item[0] }}'
             dest: '{{ item[1] }}'
             mode: pull
-            verify_host: true
+            verify_host: True
+            owner: False
+            group: False
           loop:
             - ['{{ _encrypt_tempdir.path }}/{{ playbook_name }}.log.gpg', '{{ zuul.executor.log_root }}/{{ playbook_name }}.log.gpg']
             - ['{{ _encrypt_tempdir.path }}/download-logs.sh' , '{{ zuul.executor.log_root }}/download-gpg-logs.sh']


### PR DESCRIPTION
when fetching encrypted logs we started seeing issue with keeping attrs
after zuul migration. Ownership is anyway not what we need so we can
safely skip that.
