### PR TITLE
fix: stop forcing ansible python path on bridge

### DIFF
--- a/inventory/service/host_vars/bridge.eco.tsi-dev.otc-service.com.yaml
+++ b/inventory/service/host_vars/bridge.eco.tsi-dev.otc-service.com.yaml
@@ -1,5 +1,4 @@
 use_upstream_docker: False
-ansible_python_interpreter: /usr/ansible-venv/bin/python
 
 x509_certificates:
   - "zuul-gearman-client"


### PR DESCRIPTION
in one of last changes we started forcing ansible to use
/usr/ansible-venv python interpreter. This causes inability to use
certain system-only packages (firewalld). Instead other jobs would need
to be extended with installing dependent packages no into the venv
