### PR TITLE
Set vault tag explicitly for siwft-proxy app

### DIFF
--- a/kubernetes/swift-proxy/base/kustomization.yaml
+++ b/kubernetes/swift-proxy/base/kustomization.yaml
@@ -13,6 +13,8 @@ labels:
 images:
   - name: zuul-storage-proxy
     newName: quay.io/zuul-ci/zuul-storage-proxy
+  - name: vault
+    newTag: 1.13.3
 
 resources:
   - service.yaml


### PR DESCRIPTION
Set the version explicitly, since tag "latest" has been removed from dockerhub