### PR TITLE
update hacking version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,3 +4,4 @@ reno>=3.1.0 # Apache-2.0
 sphinx>=4.0.0 # BSD
 zuul-sphinx>=0.1.1
 graphviz
+ansible-core

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ install_command = pip install {opts} {packages}
 
 [testenv:linters]
 deps =
-  hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
+  hacking>=6.0.1,<7.0.0 # Apache-2.0
   bashate>=0.2 # Apache-2.0
   PyYAML>=3.10.0 # MIT
   ansible
@@ -18,7 +18,9 @@ deps =
   testtools
   mock
   yamllint
-whitelist_externals = bash
+allowlist_externals = 
+  bash
+  {toxinidir}/tools/run-bashate.sh
 setenv =
   ANSIBLE_LIBRARY= {toxinidir}/tools/fake-ansible/library
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,8 @@ commands =
 
 [testenv:docs]
 deps = -r{toxinidir}/doc/requirements.txt
-whitelist_externals = cp
+allowlist_externals = 
+  cp
 commands = 
   python3 {toxinidir}/tools/generate-diagrams.py --path doc/source/_svg
   sphinx-build -W -E -b html doc/source doc/build/html -vv


### PR DESCRIPTION
hacking! is pulling flake==2.5.5 which is not working with py311. Fix
this by updating to the much much newer version (with package rename) to
6.0.1.
