### PR TITLE
workaround for search from old backend for swiss-archive

### DIFF
--- a/kubernetes/docsportal/overlays/helpcenter_swiss_archive/configs/nginx-site.conf
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_archive/configs/nginx-site.conf
@@ -43,6 +43,10 @@ upstream backend {
   server swift.eco.tsi-dev.otc-service.com:443;
 }
 
+upstream old_backend {
+  server 185.153.107.33:443;
+}
+
 # server_names_hash_bucket_size 128;
 server {
   # skip some normal config like listen, log
@@ -75,4 +79,11 @@ server {
     # If we get 30x back from backend - rewrite it again to something we would understand
     proxy_redirect ~*/v1/AUTH_f90ec3d7f6724ad79aed4e10b3956469/(.*)$ https://docs-archive.sc.otc.t-systems.com/$1;
   }
+
+  #workaround for search
+  location ~ /HelpCenter/ {
+    proxy_pass https://old_backend/$uri;
+    proxy_redirect ~*/HelpCenter/docClassInfo/(.*)$ https://docs-archive.sc.otc.t-systems.com/HelpCenter/docClassInfo/$1;
+  }
+
 }


### PR DESCRIPTION
currently search is not working on docs-archive and I added a workaround to proxy the old search backend