### PR TITLE
Update version for loki helm chart 5.5.0 -> 5.34.0

### DIFF
--- a/inventory/service/group_vars/k8s-controller.yaml
+++ b/inventory/service/group_vars/k8s-controller.yaml
@@ -237,7 +237,7 @@ helm_chart_instances:
     repo_name: grafana
     name: loki
     ref: grafana/loki
-    version: 5.5.0
+    version: 5.34.0
     namespace: loki
     values_template: "templates/charts/loki/loki-values.yaml.j2"
   otcinfra_promtail:


### PR DESCRIPTION
Updated to the latest available helmchart loki version