### PR TITLE
Change wrong config name for alertmanagerSpec section

### DIFF
--- a/playbooks/templates/charts/prometheus/prometheus-otcinfra-values.yaml.j2
+++ b/playbooks/templates/charts/prometheus/prometheus-otcinfra-values.yaml.j2
@@ -15,7 +15,7 @@ alertmanager:
       - hosts:
         - "{{ chart.alertmanager_fqdn }}"
         secretName: alertmanager-mon
-  alertamanagerSpec:
+  alertmanagerSpec:
     externalUrl: "https://{{ chart.alertmanager_fqdn }}"
   config:
     route:

--- a/playbooks/templates/charts/prometheus/prometheus-otcinfra2-values.yaml.j2
+++ b/playbooks/templates/charts/prometheus/prometheus-otcinfra2-values.yaml.j2
@@ -15,7 +15,7 @@ alertmanager:
       - hosts:
         - "{{ chart.alertmanager_fqdn }}"
         secretName: alertmanager-mon
-  alertamanagerSpec:
+  alertmanagerSpec:
     externalUrl: "https://{{ chart.alertmanager_fqdn }}"
   config:
     route:


### PR DESCRIPTION
alertmanager.alertmanagerSpec

https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack?modal=values&path=alertmanager.alertmanagerSpec