### PR TITLE
Remove cpu limits for configmap-sync and redirect-configmap-sync pods

### DIFF
--- a/kubernetes/docsportal/overlays/helpcenter_beta/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_beta/kustomization.yaml
@@ -305,7 +305,6 @@ patches:
                 image: kiwigrid/k8s-sidecar
                 resources:
                   limits:
-                    cpu: "200m"
                     memory: "100Mi"
                   requests:
                     cpu: "10m"

--- a/kubernetes/docsportal/overlays/helpcenter_internal/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_internal/kustomization.yaml
@@ -320,7 +320,6 @@ patches:
                 image: kiwigrid/k8s-sidecar
                 resources:
                   limits:
-                    cpu: "200m"
                     memory: "100Mi"
                   requests:
                     cpu: "10m"

--- a/kubernetes/docsportal/overlays/helpcenter_public/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_public/kustomization.yaml
@@ -305,7 +305,6 @@ patches:
                 image: kiwigrid/k8s-sidecar
                 resources:
                   limits:
-                    cpu: "50m"
                     memory: "100Mi"
                   requests:
                     cpu: "10m"

--- a/kubernetes/docsportal/overlays/helpcenter_swiss_beta/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_beta/kustomization.yaml
@@ -176,7 +176,6 @@ patches:
                 image: kiwigrid/k8s-sidecar
                 resources:
                   limits:
-                    cpu: "50m"
                     memory: "100Mi"
                   requests:
                     cpu: "10m"

--- a/kubernetes/docsportal/overlays/helpcenter_swiss_internal/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_internal/kustomization.yaml
@@ -270,7 +270,6 @@ patches:
                 image: kiwigrid/k8s-sidecar
                 resources:
                   limits:
-                    cpu: "200m"
                     memory: "100Mi"
                   requests:
                     cpu: "10m"

--- a/kubernetes/docsportal/overlays/helpcenter_swiss_public/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_public/kustomization.yaml
@@ -176,7 +176,6 @@ patches:
                 image: kiwigrid/k8s-sidecar
                 resources:
                   limits:
-                    cpu: "50m"
                     memory: "100Mi"
                   requests:
                     cpu: "10m"

--- a/playbooks/roles/document_hosting_k8s/templates/deployment.yaml.j2
+++ b/playbooks/roles/document_hosting_k8s/templates/deployment.yaml.j2
@@ -66,7 +66,6 @@ spec:
               value: configmap
           resources:
             limits:
-              cpu: "200m"
               memory: "100Mi"
             requests:
               cpu: "10m"


### PR DESCRIPTION
The CPUThrottlingHigh is an alert created by the [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin) project. The best practice is to remove limit for cpu.