### PR TITLE
Update promtail, telegraf, node-exporter as non disruptive components

### DIFF
--- a/playbooks/roles/node-exporter/templates/node-exporter.service.j2
+++ b/playbooks/roles/node-exporter/templates/node-exporter.service.j2
@@ -27,6 +27,7 @@ ExecStart=/usr/bin/podman run \
           -v /sys:/host/sys:ro \
           -v /:/rootfs:ro \
           -v {{ node_exporter_config_path }}/web-config.yml:/web-config.yml:ro \
+          --log-driver=journald \
           {{ node_exporter_image }} \
           --path.procfs=/host/proc \
           --path.sysfs=/host/sys \
@@ -63,6 +64,7 @@ ExecStart=/usr/bin/docker run \
           -v /sys:/host/sys:ro \
           -v /:/rootfs:ro \
           -v {{ node_exporter_config_path }}/web-config.yml:/web-config.yml:ro \
+          --log-driver=journald \
           {{ node_exporter_image }} \
           --path.procfs=/host/proc \
           --path.sysfs=/host/sys \

--- a/playbooks/roles/promtail/templates/config.yml.j2
+++ b/playbooks/roles/promtail/templates/config.yml.j2
@@ -19,11 +19,12 @@ scrape_configs:
       max_age: 12h
       labels:
         job: systemd-journal
+        hostname:  {{ inventory_hostname }}
     relabel_configs:
       - source_labels: ['__journal__systemd_unit']
         target_label: 'unit'
-      - source_labels: ['__journal__hostname']
-        target_label: 'hostname'
+      - source_labels: ['__journal_container_name']
+        target_label: 'container_name'
   - job_name: audit
     pipeline_stages:
     - match:
@@ -38,5 +39,5 @@ scrape_configs:
           - localhost
         labels:
           job: audit
-          hostname: {{ ansible_fqdn }}
+          hostname: {{ inventory_hostname }}
           __path__: /var/log/audit/audit.log

--- a/playbooks/roles/promtail/templates/promtail.service.j2
+++ b/playbooks/roles/promtail/templates/promtail.service.j2
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/podman run \
           --cgroups=no-conmon \
           -d \
           --name promtail \
-          --log-opt=path=/dev/null \
+          --log-driver=journald \
           --security-opt label=disable \
           -v /etc/promtail/config.yml:/etc/promtail/config.yml:ro \
           -v /var/log/journal:/var/log/journal:ro \
@@ -60,6 +60,7 @@ ExecStart=/usr/bin/docker run  \
           -v /var/log/journal:/var/log/journal:ro \
           -v /var/log/audit:/var/log/audit:ro \
           -v promtail-run:/run/promtail:rw \
+          --log-driver=journald \
           -p 3101:3101 \
           {{ promtail_image }}
 

--- a/playbooks/roles/telegraf/templates/telegraf.service.j2
+++ b/playbooks/roles/telegraf/templates/telegraf.service.j2
@@ -25,7 +25,7 @@ ExecStart=/usr/bin/podman run \
           -d \
           --name telegraf \
           -p 8888:8888 \
-          --log-opt=path=/dev/null \
+          --log-driver=journald \
           -v /etc/telegraf:/etc/telegraf:ro \
           -v /:/rootfs:ro -e HOST_MOUNT_PREFIX=/rootfs -e HOST_PROC=/rootfs/proc \
           {{ telegraf_image }}
@@ -56,6 +56,7 @@ ExecStart=/usr/bin/docker run  \
           --user telegraf \
           --name telegraf \
           -p 8888:8888 \
+          --log-driver=journald \
           -v /etc/telegraf:/etc/telegraf:ro \
           -v /:/rootfs:ro -e HOST_MOUNT_PREFIX=/rootfs -e HOST_PROC=/rootfs/proc \
           {{ telegraf_image }}


### PR DESCRIPTION
Enabling collection logs for containers from VM forpromtail, telegraf, node-exporter containers;
Solving the problem of rotating docker container logs;