### PR TITLE
removing pseudo-tty option which breaks cli output

### DIFF
--- a/playbooks/roles/install-osc-container/files/openstack
+++ b/playbooks/roles/install-osc-container/files/openstack
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec docker run -it --rm \
+exec docker run -i --rm \
   -v/etc/openstack:/etc/openstack \
   quay.io/opentelekomcloud/python-openstackclient \
   openstack $@


### PR DESCRIPTION
This might be the issue of the docker image itself where it produces carriage return character at the end of line