### PR TITLE
Add ingnore_errors: true for Search and Configure priv commands on base/audit role

### DIFF
--- a/playbooks/roles/base/audit/tasks/main.yaml
+++ b/playbooks/roles/base/audit/tasks/main.yaml
@@ -90,6 +90,7 @@
   check_mode: no
   when: 
     - configure_privileged_commands | default(true)
+  ignore_errors: true
 
 - name: Configure logging for priviledged commands
   ansible.builtin.lineinfile:
@@ -100,6 +101,7 @@
   notify: restart auditd
   when: 
     - configure_privileged_commands | default(true)
+  ignore_errors: true
 
 - name: Make audit configuration immutable
   ansible.builtin.lineinfile:


### PR DESCRIPTION
Added the `ignore_errors: true` parameter to Ansible tasks to prevent interruptions caused by errors when searching for and logging privileged commands on `base/audit` role for `infra-prod-base-ext` zuul job. 

These changes allow the playbook to continue execution even if some commands return errors related to non-existent container binaries. Examples of such errors include:

```
fatal: [executor4.apimon.eco.tsi-dev.otc-service.com]: FAILED! => {
"changed": false,
"cmd": "df --local -P | awk {'if (NR!=1) print $6'}  \\\n| xargs -I '{}' find '{}' -xdev -type f \\( -perm -4000 -o -perm -2000 \\) -print 2>/dev/null\n",
"delta": "0:00:01.915619",
"end": "2024-08-06 08:03:51.166100",
"rc": 123,
"start": "2024-08-06 08:03:49.250481"
}
```

```
failed: [graphite1.eco.tsi-dev.otc-service.com] (item=/var/lib/containers/storage/overlay/814bff7343242acfd20a2c841e041dd57c50f0cf844d4abd2329f78b992197f4/diff/sbin/unix_chkpwd) => {
"ansible_loop_var": "item",
"changed": false,
"item": "/var/lib/containers/storage/overlay/814bff7343242acfd20a2c841e041dd57c50f0cf844d4abd2329f78b992197f4/diff/sbin/unix_chkpwd",
"rc": -13
}
```

These errors occurred sporadically on various hosts, often due to attempts to access binaries from non-existent containers. Adding `ignore_errors: true` helps ensure the playbook runs more reliably by ignoring such transient errors.