### PR TITLE
upgrade prom blackbox chart to 9.2.0

### DIFF
--- a/inventory/service/group_vars/k8s-controller.yaml
+++ b/inventory/service/group_vars/k8s-controller.yaml
@@ -276,7 +276,7 @@ helm_chart_instances:
     repo_name: prometheus-community
     name: prometheus-blackbox-exporter
     ref: prometheus-community/prometheus-blackbox-exporter
-    version: 8.4.0
+    version: 9.2.0
     namespace: monitoring
     values_template: "templates/charts/prometheus-blackbox/prometheus-blackbox-otcinfra-values.yaml.j2"
 # otcinfra2_prometheus:


### PR DESCRIPTION
to fix issue with:
```
Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: resource mapping not found for name: "prometheus-blackbox-exporter-psp" namespace: "monitoring" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first
```