### PR TITLE
Upgrade kube-prometheus-stack and adjust service monitor configuration

### DIFF
--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/Chart.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for Kubernetes that includes kube-prometheus-stack and
 version: 0.1.0
 dependencies:
   - name: kube-prometheus-stack
-    version: "51.8.1"
+    version: "69.7.2"
     repository: "https://prometheus-community.github.io/helm-charts"

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-de.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-de.yaml
@@ -128,7 +128,7 @@ kube-prometheus-stack:
               name: basic-auth
               key: vmauth_password
       serviceMonitorSelector: {}
-      podMonitorSelector: {}
+      serviceMonitorSelectorNilUsesHelmValues: false
 
 goNeb:
   enabled: true

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-nl.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-nl.yaml
@@ -128,7 +128,7 @@ kube-prometheus-stack:
               name: basic-auth
               key: vmauth_password
       serviceMonitorSelector: {}
-      podMonitorSelector: {}
+      serviceMonitorSelectorNilUsesHelmValues: false
 
 goNeb:
   enabled: true

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcci.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcci.yaml
@@ -109,42 +109,7 @@ kube-prometheus-stack:
               name: basic-auth
               key: vmauth_password
       serviceMonitorSelector: {}
-      podMonitorSelector: {}
-      # additionalScrapeConfigs:
-      # - job_name: 'cert-manager'
-      #   kubernetes_sd_configs:
-      #   - role: endpoints
-      #     namespaces:
-      #       names:
-      #       - cert-manager
-      #   scheme: https
-      #   tls_config:
-      #     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      #   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      #   relabel_configs:
-      #   - source_labels: [__meta_kubernetes_service_name]
-      #     action: keep
-      #     regex: cert-manager
-      #   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-      #     action: keep
-      #     regex: true
-      #   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-      #     action: replace
-      #     target_label: __metrics_path__
-      #     regex: (.+)
-      #   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-      #     action: replace
-      #     regex: ([^:]+)(?::\d+)?;(\d+)
-      #     replacement: $1:$2
-      #     target_label: __address__
-      #   - action: labelmap
-      #     regex: __meta_kubernetes_pod_label_(.+)
-      #   - source_labels: [__meta_kubernetes_namespace]
-      #     action: replace
-      #     target_label: kubernetes_namespace
-      #   - source_labels: [__meta_kubernetes_pod_name]
-      #     action: replace
-      #     target_label: kubernetes_pod_name
+      serviceMonitorSelectorNilUsesHelmValues: false
 
 goNeb:
   enabled: true

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra.yaml
@@ -250,40 +250,6 @@ kube-prometheus-stack:
         secretName: prometheus-mon
     prometheusSpec:
       additionalScrapeConfigs:
-      - job_name: 'cert-manager'
-        kubernetes_sd_configs:
-        - role: endpoints
-          namespaces:
-            names:
-            - cert-manager
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          action: keep
-          regex: cert-manager
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: kubernetes_pod_name
       - job_name: blackbox_http_2xx
         metrics_path: /probe
         params:
@@ -450,7 +416,7 @@ kube-prometheus-stack:
               key: vmauth_password
       retention: 7d
       serviceMonitorSelector: {}
-      podMonitorSelector: {}
+      serviceMonitorSelectorNilUsesHelmValues: false
 
 goNeb:
   enabled: true

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra2.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra2.yaml
@@ -113,42 +113,7 @@ kube-prometheus-stack:
               name: basic-auth
               key: vmauth_password
       serviceMonitorSelector: {}
-      podMonitorSelector: {}
-      # additionalScrapeConfigs:
-      # - job_name: 'cert-manager'
-      #   kubernetes_sd_configs:
-      #   - role: endpoints
-      #     namespaces:
-      #       names:
-      #       - cert-manager
-      #   scheme: https
-      #   tls_config:
-      #     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      #   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      #   relabel_configs:
-      #   - source_labels: [__meta_kubernetes_service_name]
-      #     action: keep
-      #     regex: cert-manager
-      #   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-      #     action: keep
-      #     regex: true
-      #   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-      #     action: replace
-      #     target_label: __metrics_path__
-      #     regex: (.+)
-      #   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-      #     action: replace
-      #     regex: ([^:]+)(?::\d+)?;(\d+)
-      #     replacement: $1:$2
-      #     target_label: __address__
-      #   - action: labelmap
-      #     regex: __meta_kubernetes_pod_label_(.+)
-      #   - source_labels: [__meta_kubernetes_namespace]
-      #     action: replace
-      #     target_label: kubernetes_namespace
-      #   - source_labels: [__meta_kubernetes_pod_name]
-      #     action: replace
-      #     target_label: kubernetes_pod_name
+      serviceMonitorSelectorNilUsesHelmValues: false
 
 goNeb:
   enabled: true


### PR DESCRIPTION
- Bump kube-prometheus-stack chart version from 51.8.1 to 69.7.2
- Set serviceMonitorSelectorNilUsesHelmValues to false across multiple environments
- Remove commented-out cert-manager scrape configs