### PR TITLE
Enable CRDs for kube-prometheus-stack across environments

### DIFF
--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-de.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-de.yaml
@@ -1,4 +1,6 @@
 kube-prometheus-stack:
+  crds:
+    enabled: true
   alertmanager:
     alertmanagerSpec:
       externalUrl: https://alertmanager-de.cloudmon.eco.tsi-dev.otc-service.com

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-nl.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-nl.yaml
@@ -1,4 +1,6 @@
 kube-prometheus-stack:
+  crds:
+    enabled: true
   alertmanager:
     alertmanagerSpec:
       externalUrl: https://alertmanager-nl.cloudmon.eco.tsi-dev.otc-service.com

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcci.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcci.yaml
@@ -1,4 +1,6 @@
 kube-prometheus-stack:
+  crds:
+    enabled: true
   alertmanager:
     alertmanagerSpec:
       externalUrl: https://alertmanager-mon.zuul.otc-service.com

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra.yaml
@@ -1,4 +1,6 @@
 kube-prometheus-stack:
+  crds:
+    enabled: true
   additionalPrometheusRulesMap:
     endpoint-mon:
       groups:

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra2.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra2.yaml
@@ -1,4 +1,6 @@
 kube-prometheus-stack:
+  crds:
+    enabled: true
   alertmanager:
     alertmanagerSpec:
       externalUrl: https://alertamanager-mon.infra2.eco.tsi-dev.otc-service.com


### PR DESCRIPTION
Add `crds.enabled: true` configuration to kube-prometheus-stack values files for multiple environments to ensure proper CRD installation and management.

Environments updated:
- cloudmon-de
- cloudmon-nl
- otcci
- otcinfra
- otcinfra2