### PR TITLE
Gitea logging and mailer configuration

### DIFF
--- a/playbooks/roles/gitea/templates/app.ini.j2
+++ b/playbooks/roles/gitea/templates/app.ini.j2
@@ -112,7 +112,8 @@ LEVEL = Debug
 ;DISABLE_ROUTER_LOG=false
 ;;
 ;; Set the log "modes" for the router log (if file is set the log file will default to router.log)
-ROUTER = console
+;;ROUTER = console
+logger.router.MODE = ,
 ;;
 ;; The router will log different things at different levels.
 ;;
@@ -131,9 +132,8 @@ ROUTER = console
 ;;
 [log.logger.access]
 MODE = console, file
-
-[log.logger.router]
-MODE = console
+LEVEL = Warn
+FILE_NAME = access.log
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -385,9 +385,8 @@ ENABLE_AUTO_REGISTRATION = true
 [mailer]
 ENABLED        = true
 FROM           = {{ gitea_mailer_from }}
-MAILER_TYPE    = {{ gitea_mailer_type }}
-HOST           = {{ gitea_mailer_host }}
-IS_TLS_ENABLED = {{ gitea_mailer_is_tls_enabled }}
+PROTOCOL       = {{ gitea_mailer_type }}
+SMTP_ADDR      = {{ gitea_mailer_host }}
 USER           = {{ gitea_mailer_user }}
 PASSWD         = {{ gitea_mailer_passwd }}
 {% endif %}


### PR DESCRIPTION
- Updated router logging configuration to use logger.router.MODE
- Changed access logger level to Warn and specified access log file
- Modified mailer settings: replaced MAILER_TYPE with PROTOCOL and HOST with SMTP_ADDR