### PR TITLE
Add cert-manager annotation for private key rotation policy across ingresses

### DIFF
--- a/kubernetes/argocd-apps/system/grafana/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/grafana/values-otcinfra.yaml
@@ -135,6 +135,7 @@ grafana:
       cert-manager.io/cluster-issuer: letsencrypt-prod
       cert-manager.io/private-key-algorithm: RSA
       cert-manager.io/private-key-size: "4096"
+      cert-manager.io/private-key-rotation-policy: Always
     path: /
     port: http
     pathType: Prefix

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-de.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-de.yaml
@@ -49,6 +49,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - alertmanager-de.cloudmon.eco.tsi-dev.otc-service.com
@@ -74,6 +75,7 @@ kube-prometheus-stack:
         cert-manager.io/cluster-issuer: letsencrypt-prod
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - grafana-de.cloudmon.eco.tsi-dev.otc-service.com
@@ -104,6 +106,7 @@ kube-prometheus-stack:
         cert-manager.io/cluster-issuer: letsencrypt-prod
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
         nginx.ingress.kubernetes.io/auth-realm: Authentication Required
         nginx.ingress.kubernetes.io/auth-secret: basic-auth
         nginx.ingress.kubernetes.io/auth-type: basic

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-nl.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-cloudmon-nl.yaml
@@ -49,6 +49,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - alertmanager-nl.cloudmon.eco.tsi-dev.otc-service.com
@@ -74,6 +75,7 @@ kube-prometheus-stack:
         cert-manager.io/cluster-issuer: letsencrypt-prod
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - grafana-nl.cloudmon.eco.tsi-dev.otc-service.com
@@ -107,6 +109,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - prometheus-nl.cloudmon.eco.tsi-dev.otc-service.com

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcci.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcci.yaml
@@ -49,6 +49,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - alertmanager-mon.zuul.otc-service.com
@@ -90,6 +91,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - prometheus-mon.zuul.otc-service.com

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra.yaml
@@ -203,6 +203,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - alertamanager-mon.infra.eco.tsi-dev.otc-service.com
@@ -244,6 +245,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - prometheus-mon.infra.eco.tsi-dev.otc-service.com

--- a/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra2.yaml
+++ b/kubernetes/argocd-apps/system/kube-prometheus-stack/values-otcinfra2.yaml
@@ -49,6 +49,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - alertamanager-mon.infra2.eco.tsi-dev.otc-service.com
@@ -90,6 +91,7 @@ kube-prometheus-stack:
         nginx.ingress.kubernetes.io/auth-type: basic
         cert-manager.io/private-key-algorithm: RSA
         cert-manager.io/private-key-size: "4096"
+        cert-manager.io/private-key-rotation-policy: Always
       enabled: true
       hosts:
       - prometheus-mon.infra2.eco.tsi-dev.otc-service.com

--- a/kubernetes/argocd-apps/system/victoria-metrics-auth/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/victoria-metrics-auth/values-otcinfra.yaml
@@ -28,6 +28,7 @@ victoria-metrics-auth:
       cert-manager.io/cluster-issuer: letsencrypt-prod
       cert-manager.io/private-key-algorithm: RSA
       cert-manager.io/private-key-size: "4096"
+      cert-manager.io/private-key-rotation-policy: Always
     hosts:
       - name: vm.eco.tsi-dev.otc-service.com
         path: /

--- a/kubernetes/backstage/overlays/dev/kustomization.yaml
+++ b/kubernetes/backstage/overlays/dev/kustomization.yaml
@@ -52,6 +52,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/backstage/overlays/prod/kustomization.yaml
+++ b/kubernetes/backstage/overlays/prod/kustomization.yaml
@@ -52,6 +52,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/circle-partner-navigator/base/cpn-front-ingress.yaml
+++ b/kubernetes/circle-partner-navigator/base/cpn-front-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     cert-manager.io/private-key-algorithm: RSA
     cert-manager.io/private-key-size: "4096"
+    cert-manager.io/private-key-rotation-policy: Always
 spec:
   ingressClassName: nginx
   rules:

--- a/kubernetes/circle-partner-navigator/base/cpn-ingress.yaml
+++ b/kubernetes/circle-partner-navigator/base/cpn-ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
     cert-manager.io/private-key-algorithm: RSA
     cert-manager.io/private-key-size: "4096"
+    cert-manager.io/private-key-rotation-policy: Always
 spec:
   ingressClassName: nginx
   rules:

--- a/kubernetes/dep-track/overlays/prod/kustomization.yaml
+++ b/kubernetes/dep-track/overlays/prod/kustomization.yaml
@@ -25,6 +25,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/docsportal/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/docsportal/kustomization.yaml
@@ -33,6 +33,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/helpcenter_archive/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_archive/kustomization.yaml
@@ -33,6 +33,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/helpcenter_beta/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_beta/kustomization.yaml
@@ -260,6 +260,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/helpcenter_internal/ingress-oauth.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_internal/ingress-oauth.yaml
@@ -5,6 +5,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     cert-manager.io/private-key-algorithm: RSA
     cert-manager.io/private-key-size: "4096"
+    cert-manager.io/private-key-rotation-policy: Always
   labels:
     app.kubernetes.io/instance: helpcenter-internal-oauth
     app.kubernetes.io/managed-by: kustomize

--- a/kubernetes/docsportal/overlays/helpcenter_public/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_public/kustomization.yaml
@@ -296,6 +296,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/helpcenter_swiss_archive/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_archive/kustomization.yaml
@@ -47,6 +47,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/helpcenter_swiss_beta/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_beta/kustomization.yaml
@@ -131,6 +131,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/helpcenter_swiss_internal/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_internal/kustomization.yaml
@@ -225,6 +225,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/docsportal/overlays/helpcenter_swiss_public/kustomization.yaml
+++ b/kubernetes/docsportal/overlays/helpcenter_swiss_public/kustomization.yaml
@@ -134,6 +134,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/kubernetes/mcaptcha/base/ingress.yaml
+++ b/kubernetes/mcaptcha/base/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     cert-manager.io/private-key-algorithm: RSA
     cert-manager.io/private-key-size: "4096"
+    cert-manager.io/private-key-rotation-policy: Always
 spec:
   rules:
     - host: mcaptcha.otc-service.com

--- a/kubernetes/umami/base/ingress.yaml
+++ b/kubernetes/umami/base/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     cert-manager.io/private-key-algorithm: RSA
     cert-manager.io/private-key-size: "4096"
+    cert-manager.io/private-key-rotation-policy: Always
 spec:
   ingressClassName: nginx
   rules:

--- a/kubernetes/zuul/overlays/zuul_ci/kustomization.yaml
+++ b/kubernetes/zuul/overlays/zuul_ci/kustomization.yaml
@@ -149,6 +149,7 @@ patches:
           cert-manager.io/cluster-issuer: letsencrypt-prod
           cert-manager.io/private-key-algorithm: RSA
           cert-manager.io/private-key-size: "4096"
+          cert-manager.io/private-key-rotation-policy: Always
       - op: replace
         path: /spec/tls
         value:

--- a/playbooks/templates/charts/argocd/argocd-values.yaml.j2
+++ b/playbooks/templates/charts/argocd/argocd-values.yaml.j2
@@ -32,6 +32,7 @@ server:
       nginx.ingress.kubernetes.io/ssl-passthrough: "true"
       cert-manager.io/private-key-algorithm: RSA
       cert-manager.io/private-key-size: "4096"
+      cert-manager.io/private-key-rotation-policy: Always
     ingressClassName: "nginx"
 
     hosts:


### PR DESCRIPTION
`Warning  CannotRegenerateKey  4m50s (x3 over 47h)  cert-manager-certificates-key-manager  User intervention required: existing private key in Secret "argocd-server-tls" does not match requirements on Certificate resource, mismatching fields: [spec.privateKey.size], but cert-manager cannot create new private key as the Certificate's .spec.privateKey.rotationPolicy is unset or set to Never. To allow cert-manager to create a new private key you can set .spec.privateKey.rotationPolicy to 'Always' (this will result in the private key being regenerated every time a cert is renewed)`