### PR TITLE
Update ArgoCD version and add global domain configuration

### DIFF
--- a/inventory/service/group_vars/k8s-controller.yaml
+++ b/inventory/service/group_vars/k8s-controller.yaml
@@ -40,7 +40,7 @@ helm_chart_instances:
     repo_name: argocd
     name: argocd
     ref: argocd/argo-cd
-    version: 7.6.12
+    version: 7.8.15
     namespace: argocd
     values_template: "templates/charts/argocd/argocd-values.yaml.j2"
   otcinfra_nginx-ingress:

--- a/playbooks/templates/charts/argocd/argocd-values.yaml.j2
+++ b/playbooks/templates/charts/argocd/argocd-values.yaml.j2
@@ -11,6 +11,9 @@ crds:
 dex:
   enabled: false
 
+global:
+  domain: argocd.eco.tsi-dev.otc-service.com
+
 ## Server
 server:
   extensions:
@@ -34,16 +37,8 @@ server:
       cert-manager.io/private-key-size: "4096"
       cert-manager.io/private-key-rotation-policy: Always
     ingressClassName: "nginx"
-
-    hosts:
-      - argocd.eco.tsi-dev.otc-service.com
-    paths:
-      - /
-    tls:
-      - secretName: argocd-cert
-        hosts:
-          - argocd.eco.tsi-dev.otc-service.com
-    https: true
+    path: /
+    tls: true
 
 repoServer:
   env:


### PR DESCRIPTION
- Updated ArgoCD Helm chart version from 7.6.12 to 7.8.15 in k8s-controller.yaml.
- Added global domain configuration in argocd-values.yaml.j2 for improved domain management.