### PR TITLE
1254 - Addition of docker check of dependabot for system-config repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "[helm] "
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "[docker] "
+


### PR DESCRIPTION
Addapted `dependabot.yaml` for docker check on daily bases

closes #1254 