### PR TITLE
Update Victoria Metrics image tags to v1.117.1

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,6 +10,6 @@ otcdocstheme<2.0.0 # Apache-2.0
 
 otc-sphinx-directives>=0.1.0
 sphinx-minify>=0.0.1 # Apache-2.0
-git+https://gitea.eco.tsi-dev.otc-service.com/infra/otc-metadata.git#egg=otc_metadata
+git+https://gitea.eco.tsi-dev.otc-service.com/infra/otc-metadata-rework.git#egg=otc_metadata
 setuptools
 gitpython

--- a/kubernetes/argocd-apps/system/victoria-metrics-auth/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/victoria-metrics-auth/values-otcinfra.yaml
@@ -2,7 +2,7 @@ victoria-metrics-auth:
   replicaCount: 2
   image:
     repository: victoriametrics/vmauth
-    tag: v1.100.1
+    tag: "v1.117.1"
     pullPolicy: IfNotPresent
   containerWorkingDir: "/"
   rbac:

--- a/kubernetes/argocd-apps/system/victoria-metrics-cluster/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/victoria-metrics-cluster/values-otcinfra.yaml
@@ -2,7 +2,7 @@ victoria-metrics-cluster:
   global:
     image:
       vm:
-        tag: "v1.116.0-cluster"
+        tag: "v1.117.1-cluster"
 
   printNotes: true
 


### PR DESCRIPTION
Bump the image tag for: 

- victoria-metrics-auth from v1.100.1 to v1.117.1 
- victoria-metrics-cluster from v1.116.0-cluster to v1.117.1-cluster