### PR TITLE
fix vmstorage oomkilled

### DIFF
--- a/kubernetes/argocd-apps/system/victoria-metrics-cluster/values-otcinfra.yaml
+++ b/kubernetes/argocd-apps/system/victoria-metrics-cluster/values-otcinfra.yaml
@@ -142,10 +142,10 @@ victoria-metrics-cluster:
         failureThreshold: 10
     resources:
       limits:
-        memory: "2048Mi"
+        memory: "4Gi"
       requests:
         cpu: "500m"
-        memory: "2048Mi"
+        memory: "4Gi"
     serviceMonitor:
       enabled: true
       namespace: monitoring


### PR DESCRIPTION
Update memory resource limits for Victoria Metrics cluster in values-otcinfra.yaml from 2048Mi to 4Gi