### PR TITLE
Extending the loki minio storage to 500g

### DIFF
--- a/playbooks/templates/charts/loki/loki-values.yaml.j2
+++ b/playbooks/templates/charts/loki/loki-values.yaml.j2
@@ -117,7 +117,7 @@ minio:
   enabled: true
   rootPassword: "{{ chart.loki_minio_root_password }}"
   persistence:
-    size: 400Gi
+    size: 500Gi
     storageClass: csi-disk
   resources:
     requests:


### PR DESCRIPTION
As the change 3 months ago increased log  retention period from 1 month to 3 months the storage needs to be extended as well