### PR TITLE
reverting resizing of minio PVC due to statefulset

### DIFF
--- a/playbooks/templates/charts/loki/loki-values.yaml.j2
+++ b/playbooks/templates/charts/loki/loki-values.yaml.j2
@@ -119,7 +119,7 @@ minio:
   enabled: true
   rootPassword: "{{ chart.loki_minio_root_password }}"
   persistence:
-    size: 500Gi
+    size: 400Gi
     storageClass: csi-disk
   resources:
     requests:


### PR DESCRIPTION
Kubernetes does not allow resizing a PersistentVolumeClaim (PVC) when it’s defined inside a StatefulSet manifest, because that would require changing the volumeClaimTemplates section — and that field is immutable once the StatefulSet is created.