### PR TITLE
Improve Vault NetworkPolicy: unified allowedConsumers design

### DIFF
--- a/kubernetes/helm_charts/upstream/vault/values-preprod.yaml
+++ b/kubernetes/helm_charts/upstream/vault/values-preprod.yaml
@@ -6,15 +6,15 @@ vault:
   global:
     enabled: true
     tlsDisable: true
-  
+
     # External vault server address will be set after deployment
     # externalVaultAddr: "https://vault-lb.eco-preprod.tsi-dev.otc-service.com:8200"
-  
+
   # Vault Agent Injector configuration
   injector:
     enabled: true
     replicas: 1
-  
+
     # Resource limits for injector
     resources:
       requests:
@@ -23,12 +23,12 @@ vault:
       limits:
         memory: 512Mi
         cpu: 500m
-  
+
     # Vault agent image configuration
     agentImage:
       repository: "hashicorp/vault"
       tag: "1.19.0"
-  
+
     # Agent defaults for injected containers
     agentDefaults:
       cpuLimit: "500m"
@@ -36,17 +36,17 @@ vault:
       memLimit: "256Mi"
       memRequest: "128Mi"
       template: "map"
-  
+
   # Vault Server configuration
   server:
     enabled: true
-  
+
     # Image configuration
     image:
       repository: "hashicorp/vault"
       tag: "1.19.0"
       pullPolicy: IfNotPresent
-  
+
     # Resource configuration
     resources:
       requests:
@@ -55,7 +55,7 @@ vault:
       limits:
         memory: 2Gi
         cpu: 1000m
-  
+
     # Ingress configuration for external access
     ingress:
       enabled: true
@@ -78,10 +78,10 @@ vault:
         - secretName: vault-tls-cert
           hosts:
             - vault-lb.eco-preprod.tsi-dev.otc-service.com
-  
+
       # Override the default service to use the main vault service instead of vault-active
       activeService: false
-  
+
     # Service configuration
     service:
       enabled: true
@@ -89,18 +89,18 @@ vault:
       port: 8200
       targetPort: 8200
       annotations: {}
-  
+
     # Enable Kubernetes auth method
     authDelegator:
       enabled: true
-  
+
     # Security context
     securityContext:
       runAsNonRoot: true
       runAsUser: 100
       runAsGroup: 1000
       fsGroup: 1000
-  
+
     # Init containers to download OpenStack plugin
     extraInitContainers:
       - name: download-openstack-plugin
@@ -122,7 +122,7 @@ vault:
         volumeMounts:
           - name: plugins
             mountPath: /usr/local/libexec/vault
-  
+
     # Bank-Vaults Unsealer sidecar - automatically unseals Vault using Shamir keys
     # https://bank-vaults.dev/docs/unseal-keys/
     extraContainers:
@@ -147,49 +147,46 @@ vault:
           limits:
             cpu: 100m
             memory: 128Mi
-  
+
     # Extra volumes for plugins
     volumes:
       - name: plugins
         emptyDir: {}
-  
+
     # Volume mounts for plugins
     volumeMounts:
       - mountPath: /usr/local/libexec/vault
         name: plugins
         readOnly: true
-  
+
     # Data storage configuration
     dataStorage:
       enabled: true
       size: 10Gi
       storageClass: "csi-disk-retain"
       accessMode: ReadWriteOnce
-  
+
     # Audit storage configuration
     auditStorage:
       enabled: true
       size: 5Gi
       storageClass: "csi-disk-retain"
       accessMode: ReadWriteOnce
-  
+
     # High Availability configuration
     ha:
       enabled: true
-      replicas: 2  # Using 2 replicas for 2-node cluster
-  
-      # Disable anti-affinity for small clusters
-      affinity: ""
-  
+      replicas: 3
+
       # Integrated Raft storage for HA
       raft:
         enabled: true
         setNodeId: true
-  
+
         config: |-
           # Plugin directory
           plugin_directory = "/usr/local/libexec/vault"
-  
+
           # OTC KMS Auto-Unseal configuration (OPTIONAL - currently disabled)
           # Uncomment to enable auto-unseal with OTC DEW (AWS KMS compatible)
           # This also provides encryption for Raft data at rest
@@ -203,7 +200,7 @@ vault:
           #   # KMS Key ID - loaded from VAULT_AWSKMS_SEAL_KEY_ID env var
           #   # Create key via: OTC Console > DEW > Key Management > Create Key
           # }
-  
+
           listener "tcp" {
             tls_disable = 1
             address = "[::]:8200"
@@ -213,68 +210,71 @@ vault:
               unauthenticated_metrics_access = "true"
             }
           }
-  
+
           storage "raft" {
             path = "/vault/data"
-  
+
             retry_join {
               leader_api_addr = "http://vault-preprod-0.vault-preprod-internal:8200"
             }
             retry_join {
               leader_api_addr = "http://vault-preprod-1.vault-preprod-internal:8200"
             }
+            retry_join {
+              leader_api_addr = "http://vault-preprod-2.vault-preprod-internal:8200"
+            }
           }
-  
+
           # API and cluster addresses
           api_addr = "https://vault-lb.eco-preprod.tsi-dev.otc-service.com"
           cluster_addr = "http://POD_IP:8201"
-  
+
           # Enable Kubernetes auth method
           auth "kubernetes" {
             type = "kubernetes"
           }
-  
+
           # Enable KV v2 secrets engine
           path "secret" {
             type = "kv-v2"
           }
-  
+
           # OpenStack secrets engine will be enabled via API after plugin registration
           # path "openstack" {
           #   plugin_name = "vault-plugin-secrets-openstack"
           #   type = "plugin"
           # }
-  
+
           # Telemetry configuration for monitoring
           telemetry {
             prometheus_retention_time = "30s"
             disable_hostname = true
           }
-  
+
           # Audit logging
           audit "file" {
             type = "file"
             path = "/vault/audit/audit.log"
           }
-  
+
     # Standalone configuration (disabled in favor of HA)
     standalone:
       enabled: false
-  
+
   # UI configuration
   ui:
     enabled: false
     serviceType: "ClusterIP"
-  
+
   # CSI Provider (for secret injection)
   csi:
     enabled: true
-  
+
     image:
       repository: "hashicorp/vault-csi-provider"
       tag: "1.5.0"
       pullPolicy: IfNotPresent
-  
+
     # Resources for CSI provider
     resources:
       requests:
@@ -283,20 +283,20 @@ vault:
       limits:
         memory: 256Mi
         cpu: 250m
-  
+
     # Mount path for CSI volumes
     volumeMountPath: "/vault/secrets"
-  
+
   # Network policies
   serverTelemetry:
     # Enable Prometheus metrics
     prometheusOperator: true
-  
+
   # Additional environment variables
   extraEnvironmentVars:
     VAULT_ADDR: "https://vault-lb.eco-preprod.tsi-dev.otc-service.com"
     VAULT_API_ADDR: "https://vault-lb.eco-preprod.tsi-dev.otc-service.com"
-  
+
   # OTC KMS Auto-Unseal credentials (OPTIONAL - currently disabled)
   # Uncomment when enabling KMS auto-unseal
   # extraEnvironmentVars:


### PR DESCRIPTION
- Replace broad label-based allowedNamespaces (vault-access: true) with explicit per-namespace allowedConsumers list
- Merge separate allowedPods, allowPrometheus, and allowExternalIPs into single allowedConsumers with optional podSelector
- Remove allowExternalIPs (Gitea runners access via ingress-nginx instead)
- Only argocd namespace needs direct Vault access (vault-agent sidecars)
- All other apps use AVP in repo-server, no direct Vault connection needed
- Template now shared with Vault_migration (otcinfra2) branch