### PR TITLE
fix: remove unused opendev connection from zuul.conf.hcl

### DIFF
--- a/kubernetes/kustomize/zuul/overlays/zuul_ci/configs/zuul.conf.hcl
+++ b/kubernetes/kustomize/zuul/overlays/zuul_ci/configs/zuul.conf.hcl
@@ -71,11 +71,6 @@ webhook_token={{ .Data.data.webhook_token }}
 {{- end }}
 sshkey=/etc/zuul/connections/gitlab.key
 
-[connection "opendev"]
-name=opendev
-driver=git
-baseurl=https://opendev.org
-
 [connection "gitea"]
 name=gitea
 driver=gitea


### PR DESCRIPTION
## Summary

Remove the `[connection "opendev"]` block from `zuul.conf.hcl` since it is no longer needed.

## Context

- `opendev.org` has been returning intermittent HTTP 500 errors, causing Zuul merger failures
- `zuul/zuul-jobs` has been mirrored to Gitea at `zuul-ci/zuul-jobs` with 24h auto-sync
- Tenant configs updated to use the `gitea` connection instead of `opendev` (see opentelekomcloud-infra/zuul-config#271)
- The remaining opendev-sourced repos (`ansible-collections-openstack`, `osf/refstack-client`) had `include: []` and are removed in the zuul-config PR

## Deployment

This change should be deployed together with zuul-config PR #271.