### PR TITLE
fix(maubot): update domain from internal to production

### DIFF
--- a/kubernetes/kustomize/maubot/base/ingress.yaml
+++ b/kubernetes/kustomize/maubot/base/ingress.yaml
@@ -10,10 +10,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - matrix.eco.tsi-dev.otc-service.com
+        - matrix.otc-service.com
       secretName: maubot-tls
   rules:
-    - host: matrix.eco.tsi-dev.otc-service.com
+    - host: matrix.otc-service.com
       http:
         paths:
           - path: /_matrix/maubot

--- a/kubernetes/kustomize/maubot/overlays/prod/config.yaml
+++ b/kubernetes/kustomize/maubot/overlays/prod/config.yaml
@@ -17,13 +17,13 @@ plugin_directories:
 server:
   hostname: 0.0.0.0
   port: 29316
-  public_url: https://matrix.eco.tsi-dev.otc-service.com/_matrix/maubot
+  public_url: https://matrix.otc-service.com/_matrix/maubot
   # ui_base_path disabled — the mirrored image lacks the frontend build
   ui_base_path: ""
 
 # Homeserver for registering appservice bots
 homeservers:
-  matrix.eco.tsi-dev.otc-service.com:
+  matrix.otc-service.com:
     url: http://element-otcinfra2-synapse:8008
     secret: "<path:secret/data/element/synapse#registration-shared-secret>"
 


### PR DESCRIPTION
## Summary

Update maubot ingress and config domain from `matrix.eco.tsi-dev.otc-service.com` to `matrix.otc-service.com`.

## Problem

GitHub webhook deliveries to `matrix.otc-service.com/_` were returning **404**. The maubot ingress was configured on the internal domain `matrix.eco.tsi-dev.otc-service.com`, so requests to the production domain `matrix.otc-service.com` were hitting the well-known catch-all ingress instead of maubot, resulting in a 301 redirect to Element Web and ultimately a 404.

## Changes

- **`kubernetes/kustomize/maubot/base/ingress.yaml`**: Update host from `matrix.eco.tsi-dev.otc-service.com` to `matrix.otc-service.com`
- **`kubernetes/kustomize/maubot/overlays/prod/config.yaml`**: Update `public_url` and `homeservers` key to use `matrix.otc-service.com`

## Verification

- ArgoCD app `maubot-otcinfra2` synced successfully
- Ingress now routes `matrix.otc-service.com/_matrix/maubot` to the maubot service