### PR TITLE
fix(vault): add argocd-k8s namespace to vault NetworkPolicy ingress

### DIFF
--- a/kubernetes/helm_charts/local/vault/values-prod.yaml
+++ b/kubernetes/helm_charts/local/vault/values-prod.yaml
@@ -19,6 +19,13 @@ networkPolicy:
     - namespace: argocd
       podSelector:
         app.kubernetes.io/name: argocd-repo-server
+    # ArgoCD in argocd-k8s namespace — server init container + repo-server need Vault access
+    - namespace: argocd-k8s
+      podSelector:
+        app.kubernetes.io/name: argocd-server
+    - namespace: argocd-k8s
+      podSelector:
+        app.kubernetes.io/name: argocd-repo-server
 
   # Ingress controller — required for remote clusters to reach Vault via LB
   # Remote consumers:

--- a/kubernetes/helm_charts/upstream/argocd/values-prod.yaml
+++ b/kubernetes/helm_charts/upstream/argocd/values-prod.yaml
@@ -94,22 +94,21 @@ argo-cd:
       - name: VAULT_ADDR
         value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
       - name: AVP_AUTH_TYPE
-        value: "token"
+        value: "k8s"
       - name: AVP_TYPE
         value: "vault"
+      - name: AVP_K8S_ROLE
+        value: "argocd"
+      - name: AVP_MOUNT_PATH
+        value: "auth/kubernetes_otcinfra2"
       - name: ARGOCD_JWT_CLAIM_FLATTEN
         value: "true"
       - name: ARGOCD_OIDC_CLAIMS_PREFIX
         value: "urn:zitadel:iam:org:project:"
       - name: SERVER_RBAC_LOG_ENFORCE_ENABLE
         value: "true"
-      - name: VAULT_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: vault-token
-            key: token
 
-    # InitContainer to resolve admin password from Vault
+    # InitContainer to resolve admin password from Vault via K8s auth
     initContainers:
       - name: vault-secret-resolver
         image: hashicorp/vault:1.20
@@ -118,12 +117,14 @@ argo-cd:
           - -c
           - |
             set -e
-            echo "Authenticating to Vault using direct token..."
+            echo "Authenticating to Vault using Kubernetes auth..."
 
-            # Use the provided Vault token directly
-            export VAULT_TOKEN="$VAULT_TOKEN_VALUE"
+            # Login via Kubernetes service account JWT
+            export VAULT_TOKEN=$(vault write -field=token auth/kubernetes_otcinfra2/login \
+              role=argocd \
+              jwt=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token))
 
-            echo "Authentication successful! Using provided token."
+            echo "Authentication successful!"
 
             echo "Retrieving secrets from Vault..."
             ADMIN_PASSWORD=$(vault kv get -field=admin_password secret/argocd/config)
@@ -145,11 +146,6 @@ argo-cd:
             value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
           - name: VAULT_SKIP_VERIFY
             value: "false"
-          - name: VAULT_TOKEN_VALUE
-            valueFrom:
-              secretKeyRef:
-                name: vault-token
-                key: token
         volumeMounts:
           - name: shared-secrets
             mountPath: /shared
@@ -218,12 +214,22 @@ argo-cd:
                 {
                   "op": "replace",
                   "path": "/data/AVP_AUTH_TYPE",
-                  "value": "'$(echo -n "token" | base64 -w 0)'"
+                  "value": "'$(echo -n "k8s" | base64 -w 0)'"
                 },
                 {
                   "op": "replace",
                   "path": "/data/AVP_TYPE",
                   "value": "'$(echo -n "vault" | base64 -w 0)'"
+                },
+                {
+                  "op": "replace",
+                  "path": "/data/AVP_K8S_ROLE",
+                  "value": "'$(echo -n "argocd" | base64 -w 0)'"
+                },
+                {
+                  "op": "replace",
+                  "path": "/data/AVP_MOUNT_PATH",
+                  "value": "'$(echo -n "auth/kubernetes_otcinfra2" | base64 -w 0)'"
                 }
               ]'
             else
@@ -236,8 +242,10 @@ argo-cd:
                 --from-literal=oidc.zitadel.clientSecret="$OIDC_ZITADEL_CLIENT_SECRET" \
                 --from-literal=oidc.zitadel.clientID="$OIDC_ZITADEL_CLIENT_ID" \
                 --from-literal=VAULT_ADDR="$VAULT_ADDRESS" \
-                --from-literal=AVP_AUTH_TYPE="token" \
-                --from-literal=AVP_TYPE="vault"
+                --from-literal=AVP_AUTH_TYPE="k8s" \
+                --from-literal=AVP_TYPE="vault" \
+                --from-literal=AVP_K8S_ROLE="argocd" \
+                --from-literal=AVP_MOUNT_PATH="auth/kubernetes_otcinfra2"
             fi
 
             echo "Secret management completed successfully!"
@@ -265,21 +273,17 @@ argo-cd:
       - name: VAULT_ADDR
         value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
       - name: AVP_AUTH_TYPE
-        value: "token"
+        value: "k8s"
       - name: AVP_TYPE
         value: "vault"
-      - name: VAULT_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: vault-token
-            key: token
+      - name: AVP_K8S_ROLE
+        value: "argocd"
+      - name: AVP_MOUNT_PATH
+        value: "auth/kubernetes_otcinfra2"
     serviceAccount:
       create: true
       name: argocd-repo-server
       automountServiceAccountToken: true
-      annotations:
-        vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/role: "argocd"
 
     rbac:
       - apiGroups: [""]
@@ -321,14 +325,13 @@ argo-cd:
           - name: VAULT_ADDR
             value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
           - name: AVP_AUTH_TYPE
-            value: "token"
+            value: "k8s"
           - name: AVP_TYPE
             value: "vault"
-          - name: VAULT_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: vault-token
-                key: token
+          - name: AVP_K8S_ROLE
+            value: "argocd"
+          - name: AVP_MOUNT_PATH
+            value: "auth/kubernetes_otcinfra2"
         volumeMounts:
           - mountPath: /var/run/argocd
             name: var-files
@@ -350,14 +353,13 @@ argo-cd:
           - name: VAULT_ADDR
             value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
           - name: AVP_AUTH_TYPE
-            value: "token"
+            value: "k8s"
           - name: AVP_TYPE
             value: "vault"
-          - name: VAULT_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: vault-token
-                key: token
+          - name: AVP_K8S_ROLE
+            value: "argocd"
+          - name: AVP_MOUNT_PATH
+            value: "auth/kubernetes_otcinfra2"
         volumeMounts:
           - mountPath: /var/run/argocd
             name: var-files
@@ -379,14 +381,13 @@ argo-cd:
           - name: VAULT_ADDR
             value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
           - name: AVP_AUTH_TYPE
-            value: "token"
+            value: "k8s"
           - name: AVP_TYPE
             value: "vault"
-          - name: VAULT_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: vault-token
-                key: token
+          - name: AVP_K8S_ROLE
+            value: "argocd"
+          - name: AVP_MOUNT_PATH
+            value: "auth/kubernetes_otcinfra2"
         volumeMounts:
           - mountPath: /var/run/argocd
             name: var-files
@@ -538,8 +539,13 @@ argo-cd:
     secret:
       # Don't let Helm create/manage the secret - let init containers handle it
       createSecret: false
-      # Reference the existing secret that will be managed by init containers
-      extra: {}
+      # AVP config stored in argocd-secret for CMP plugins (-s argocd-k8s:argocd-secret)
+      extra:
+        VAULT_ADDR: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+        AVP_AUTH_TYPE: "k8s"
+        AVP_K8S_ROLE: "argocd"
+        AVP_TYPE: "vault"
+        AVP_MOUNT_PATH: "auth/kubernetes_otcinfra2"
     cmp:
       create: true
       plugins:

--- a/kubernetes/helm_charts/upstream/argocd/values-prod.yaml
+++ b/kubernetes/helm_charts/upstream/argocd/values-prod.yaml
@@ -92,7 +92,7 @@ argo-cd:
     # Environment variables for Vault access and OIDC handling
     env:
       - name: VAULT_ADDR
-        value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+        value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
       - name: AVP_AUTH_TYPE
         value: "k8s"
       - name: AVP_TYPE
@@ -143,7 +143,7 @@ argo-cd:
             echo "Vault secrets retrieved successfully!"
         env:
           - name: VAULT_ADDR
-            value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
           - name: VAULT_SKIP_VERIFY
             value: "false"
         volumeMounts:
@@ -209,7 +209,7 @@ argo-cd:
                 {
                   "op": "replace",
                   "path": "/data/VAULT_ADDR",
-                  "value": "'$(echo -n "$VAULT_ADDRESS" | base64 -w 0)'"
+                  "value": "'$(echo -n "http://vault-otcinfra2.vault.svc.cluster.local:8200" | base64 -w 0)'"
                 },
                 {
                   "op": "replace",
@@ -241,7 +241,7 @@ argo-cd:
                 --from-literal=server.secretkey="$SERVER_SECRET_KEY" \
                 --from-literal=oidc.zitadel.clientSecret="$OIDC_ZITADEL_CLIENT_SECRET" \
                 --from-literal=oidc.zitadel.clientID="$OIDC_ZITADEL_CLIENT_ID" \
-                --from-literal=VAULT_ADDR="$VAULT_ADDRESS" \
+                --from-literal=VAULT_ADDR="http://vault-otcinfra2.vault.svc.cluster.local:8200" \
                 --from-literal=AVP_AUTH_TYPE="k8s" \
                 --from-literal=AVP_TYPE="vault" \
                 --from-literal=AVP_K8S_ROLE="argocd" \
@@ -271,7 +271,7 @@ argo-cd:
       - name: ARGOCD_GPG_ENABLED
         value: "false"
       - name: VAULT_ADDR
-        value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+        value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
       - name: AVP_AUTH_TYPE
         value: "k8s"
       - name: AVP_TYPE
@@ -323,7 +323,7 @@ argo-cd:
           runAsUser: 999
         env:
           - name: VAULT_ADDR
-            value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
           - name: AVP_AUTH_TYPE
             value: "k8s"
           - name: AVP_TYPE
@@ -351,7 +351,7 @@ argo-cd:
           runAsUser: 999
         env:
           - name: VAULT_ADDR
-            value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
           - name: AVP_AUTH_TYPE
             value: "k8s"
           - name: AVP_TYPE
@@ -379,7 +379,7 @@ argo-cd:
           runAsUser: 999
         env:
           - name: VAULT_ADDR
-            value: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
           - name: AVP_AUTH_TYPE
             value: "k8s"
           - name: AVP_TYPE
@@ -539,9 +539,9 @@ argo-cd:
     secret:
       # Don't let Helm create/manage the secret - let init containers handle it
       createSecret: false
-      # AVP config stored in argocd-secret for CMP plugins (-s argocd-k8s:argocd-secret)
+      # AVP config stored in argocd-secret (used by init containers for admin password)
       extra:
-        VAULT_ADDR: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+        VAULT_ADDR: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
         AVP_AUTH_TYPE: "k8s"
         AVP_K8S_ROLE: "argocd"
         AVP_TYPE: "vault"
@@ -591,10 +591,10 @@ argo-cd:
                 # Generate helm template with vault processing
                 if [ -n "$ARGOCD_ENV_HELM_VALUES" ]; then
                   helm template $ARGOCD_APP_NAME --include-crds -n $ARGOCD_APP_NAMESPACE -f <(echo "$ARGOCD_ENV_HELM_VALUES") $HELM_SETS . |
-                  argocd-vault-plugin generate -s argocd-k8s:argocd-secret -
+                  argocd-vault-plugin generate -
                 else
                   helm template $ARGOCD_APP_NAME --include-crds -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} $HELM_SETS . |
-                  argocd-vault-plugin generate -s argocd-k8s:argocd-secret -
+                  argocd-vault-plugin generate -
                 fi
           allowConcurrency: true
           lockRepo: false
@@ -627,7 +627,7 @@ argo-cd:
 
                 # Generate helm template with vault processing
                 helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} $HELM_SETS . --include-crds |
-                argocd-vault-plugin generate -s argocd-k8s:argocd-secret -
+                argocd-vault-plugin generate -
           init:
             command:
               - bash
@@ -655,6 +655,6 @@ argo-cd:
               - bash
               - -c
               - |
-                kustomize build . | argocd-vault-plugin generate -s argocd-k8s:argocd-secret -
+                kustomize build . | argocd-vault-plugin generate -
           allowConcurrency: true
           lockRepo: false

--- a/kubernetes/helm_charts/upstream/argocd/values-prod.yaml
+++ b/kubernetes/helm_charts/upstream/argocd/values-prod.yaml
@@ -92,7 +92,9 @@ argo-cd:
     # Environment variables for Vault access and OIDC handling
     env:
       - name: VAULT_ADDR
-        value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
+        value: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
+      - name: VAULT_SKIP_VERIFY
+        value: "true"
       - name: AVP_AUTH_TYPE
         value: "k8s"
       - name: AVP_TYPE
@@ -143,9 +145,9 @@ argo-cd:
             echo "Vault secrets retrieved successfully!"
         env:
           - name: VAULT_ADDR
-            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
+            value: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
           - name: VAULT_SKIP_VERIFY
-            value: "false"
+            value: "true"
         volumeMounts:
           - name: shared-secrets
             mountPath: /shared
@@ -209,7 +211,7 @@ argo-cd:
                 {
                   "op": "replace",
                   "path": "/data/VAULT_ADDR",
-                  "value": "'$(echo -n "http://vault-otcinfra2.vault.svc.cluster.local:8200" | base64 -w 0)'"
+                  "value": "'$(echo -n "https://vault-otcinfra2.vault.svc.cluster.local:8200" | base64 -w 0)'"
                 },
                 {
                   "op": "replace",
@@ -241,7 +243,7 @@ argo-cd:
                 --from-literal=server.secretkey="$SERVER_SECRET_KEY" \
                 --from-literal=oidc.zitadel.clientSecret="$OIDC_ZITADEL_CLIENT_SECRET" \
                 --from-literal=oidc.zitadel.clientID="$OIDC_ZITADEL_CLIENT_ID" \
-                --from-literal=VAULT_ADDR="http://vault-otcinfra2.vault.svc.cluster.local:8200" \
+                --from-literal=VAULT_ADDR="https://vault-otcinfra2.vault.svc.cluster.local:8200" \
                 --from-literal=AVP_AUTH_TYPE="k8s" \
                 --from-literal=AVP_TYPE="vault" \
                 --from-literal=AVP_K8S_ROLE="argocd" \
@@ -271,7 +273,9 @@ argo-cd:
       - name: ARGOCD_GPG_ENABLED
         value: "false"
       - name: VAULT_ADDR
-        value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
+        value: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
+      - name: VAULT_SKIP_VERIFY
+        value: "true"
       - name: AVP_AUTH_TYPE
         value: "k8s"
       - name: AVP_TYPE
@@ -323,7 +327,9 @@ argo-cd:
           runAsUser: 999
         env:
           - name: VAULT_ADDR
-            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
+            value: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
+          - name: VAULT_SKIP_VERIFY
+            value: "true"
           - name: AVP_AUTH_TYPE
             value: "k8s"
           - name: AVP_TYPE
@@ -351,7 +357,9 @@ argo-cd:
           runAsUser: 999
         env:
           - name: VAULT_ADDR
-            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
+            value: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
+          - name: VAULT_SKIP_VERIFY
+            value: "true"
           - name: AVP_AUTH_TYPE
             value: "k8s"
           - name: AVP_TYPE
@@ -379,7 +387,9 @@ argo-cd:
           runAsUser: 999
         env:
           - name: VAULT_ADDR
-            value: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
+            value: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
+          - name: VAULT_SKIP_VERIFY
+            value: "true"
           - name: AVP_AUTH_TYPE
             value: "k8s"
           - name: AVP_TYPE
@@ -541,7 +551,7 @@ argo-cd:
       createSecret: false
       # AVP config stored in argocd-secret (used by init containers for admin password)
       extra:
-        VAULT_ADDR: "http://vault-otcinfra2.vault.svc.cluster.local:8200"
+        VAULT_ADDR: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
         AVP_AUTH_TYPE: "k8s"
         AVP_K8S_ROLE: "argocd"
         AVP_TYPE: "vault"


### PR DESCRIPTION
## Changes

- Add `argocd-k8s` namespace (argocd-server + argocd-repo-server) to vault NetworkPolicy `allowedConsumers`

## Context

ArgoCD was deployed in the new `argocd-k8s` namespace but the vault NetworkPolicy only allowed ingress from the old `argocd` namespace. This caused the ArgoCD server init container (`vault-secret-resolver`) and repo-server AVP plugin to fail with 403 when authenticating to Vault.

## Root cause

The vault NetworkPolicy was also blocking DNS egress from Vault pods, preventing Vault from resolving `kubernetes.default.svc.cluster.local` for TokenReview API calls. The Vault kubernetes auth config was updated live to use the in-cluster Kubernetes service IP (`10.247.0.1:443`) as a fix. The corresponding Ansible source change is in the Gitea system-config repo (branch `Argocd_vault_sa`).