### PR TITLE
fix(zitadel): add OTC_CA cert for LDAP TLS verification

### DIFF
--- a/kubernetes/helm_charts/local/zitadel/templates/otc-ca-cert-secret.yaml
+++ b/kubernetes/helm_charts/local/zitadel/templates/otc-ca-cert-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: otc-ca-cert
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "zitadel.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  otc-ca.crt: |
+    {{- .Values.otcCaCert | nindent 4 }}

--- a/kubernetes/helm_charts/local/zitadel/values-preprod.yaml
+++ b/kubernetes/helm_charts/local/zitadel/values-preprod.yaml
@@ -1,5 +1,7 @@
 masterkey: "<path:secret/data/zitadel/config#masterkey>"
 
+otcCaCert: "<path:secret/data/zitadel/config#otc_ca_cert>"
+
 configData: |
   ExternalSecure: true
   ExternalDomain: "zitadel.eco-preprod.tsi-dev.otc-service.com"

--- a/kubernetes/helm_charts/upstream/zitadel/values-preprod.yaml
+++ b/kubernetes/helm_charts/upstream/zitadel/values-preprod.yaml
@@ -184,6 +184,8 @@ zitadel:
   env:
     - name: ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_REQUIRED
       value: "false"
+    - name: SSL_CERT_FILE
+      value: "/etc/ssl/certs/otc-ca.crt"
     # - name: ZITADEL_TLS_MODE
     #   value: "external"  # Use external TLS mode for ingress TLS termination
     # - name: ZITADEL_EXTERNALSECURE
@@ -335,17 +337,17 @@ zitadel:
   # extraContainers allows you to add any sidecar containers you wish to use in the Zitadel pod.
   extraContainers: []
 
-  extraVolumes: []
-    # - name: ca-certs
-    #   secret:
-    #     defaultMode: 420
-    #     secretName: ca-certs
+  extraVolumes:
+    - name: otc-ca-cert
+      secret:
+        defaultMode: 420
+        secretName: otc-ca-cert
 
-  extraVolumeMounts: []
-    # - name: ca-certs
-    #   mountPath: /etc/ssl/certs/myca.pem
-    #   subPath: myca.pem
-    #   readOnly: true
+  extraVolumeMounts:
+    - name: otc-ca-cert
+      mountPath: /etc/ssl/certs/otc-ca.crt
+      subPath: otc-ca.crt
+      readOnly: true
 
   # extraManifests allows you to add your own Kubernetes manifests
   extraManifests: []


### PR DESCRIPTION
- Add otc-ca-cert secret template with AVP reference
- Mount CA cert into Zitadel pods via extraVolumes/extraVolumeMounts
- Set SSL_CERT_FILE env to trust OTC_CA for LDAP connections
- Fixes: x509: certificate signed by unknown authority