### PR TITLE
Fix cert-manager renewal blocked by nginx admission webhook

### DIFF
--- a/playbooks/templates/charts/ingress-nginx/ingress-nginx-values.yaml.j2
+++ b/playbooks/templates/charts/ingress-nginx/ingress-nginx-values.yaml.j2
@@ -21,3 +21,8 @@ controller:
 {% if chart.config_entries is defined %}
   config: {{ chart.config_entries }}
 {% endif %}
+  admissionWebhooks:
+    objectSelector:
+      matchExpressions:
+        - key: acme.cert-manager.io/http01-solver
+          operator: DoesNotExist


### PR DESCRIPTION
## Problem

The nginx ingress admission webhook (`ingress-nginx-admission`) rejects cert-manager ACME HTTP-01 solver ingresses because `pathType:Exact` with `.well-known/acme-challenge` paths is invalid in nginx 1.12.x.

This caused the `zuul-cert-prod` certificate on the **otcci** cluster to be stuck in `Issuing` state for 28 days, with the challenge pending indefinitely.

The same issue was previously fixed on the **otcinfra** cluster (April 17) via a manual kubectl patch.

## Root Cause

cert-manager hardcodes `pathType: Exact` in solver ingresses. The ClusterIssuer CRD only allows configuring `ingressTemplate.metadata`, not spec-level fields like pathType.

## Fix

Add `admissionWebhooks.objectSelector` to the ingress-nginx Helm values template so the admission webhook skips cert-manager solver ingresses (labeled `acme.cert-manager.io/http01-solver`).

This applies to **all clusters** (otcci, otcinfra, otcinfra2, preprod) on next Helm upgrade.

## Live Fix

The otcci webhook was also patched live via kubectl. Certificate has been renewed successfully (new expiry: 2026-07-22).