### PR TITLE
fix(carbonapi): restrict ingress to RFC1918 CIDRs only

### DIFF
--- a/playbooks/roles/carbonapi/tasks/k8s.yaml
+++ b/playbooks/roles/carbonapi/tasks/k8s.yaml
@@ -181,6 +181,8 @@
           app.kubernetes.io/name: "carbonapi"
           app.kubernetes.io/instance: "{{ instance }}"
           app.kubernetes.io/managed-by: "system-config"
+        annotations:
+          nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
       spec:
         tls:
           - hosts:


### PR DESCRIPTION
The carbonapi /metrics/find endpoint was publicly accessible without authentication, exposing internal service topology (HAProxy backends, hostnames, OpenStack Nova naming). All legitimate consumers (Grafana, HAProxy health checks, Prometheus) are RFC1918.

Applied nginx.ingress.kubernetes.io/whitelist-source-range on the ingress to block all non-RFC1918 sources. Live patch already applied to the carbonapi-main ingress on otcinfra cluster.

Fixes bug bounty report: unauthenticated Graphite metric tree enumeration on graphite-ca.eco.tsi-dev.otc-service.com