### PR TITLE
Fix URL-encoded path traversal bypass in zuul-web security proxy

### DIFF
--- a/kubernetes/kustomize/zuul/overlays/zuul_ci/configs/security-proxy-nginx.conf
+++ b/kubernetes/kustomize/zuul/overlays/zuul_ci/configs/security-proxy-nginx.conf
@@ -8,8 +8,10 @@ http {
         listen 8080;
         server_name _;
 
-        # Block requests with path parameter (CVE-PENDING)
-        if ($args ~* "path=") {
+        # Block path traversal via ?path= parameter (including all URL-encoded variants)
+        # Covers literal "path=" and single-char encodings: p=%70, a=%61, t=%74, h=%68, ===%3d
+        # e.g. p%61th=, pa%74h=, pat%68=, %70ath=, p%61%74%68=, etc.
+        if ($args ~* "(?:p|%70)(?:a|%61)(?:t|%74)(?:h|%68)(?:=|%3d)") {
             return 403 "Access forbidden: path parameter not allowed";
         }
 


### PR DESCRIPTION
## Security Fix

### Problem
The nginx security proxy filter used `$args ~* "path="` which only matches the **literal** query string. The exploit at `https://zuul.otc-service.com/?p%61th=/etc/zuul/connections/github.key` uses URL encoding (`p%61th=`) to bypass this check, since nginx's `$args` variable contains the **raw, undecoded** query string.

This exposed the GitHub App private key in plaintext.

### Fix
Updated the regex to match all single-character URL-encoded combinations of `path=`:
```
(?:p|%70)(?:a|%61)(?:t|%74)(?:h|%68)(?:=|%3d)
```

This covers: `path=`, `p%61th=`, `pa%74h=`, `pat%68=`, `%70ath=`, `p%61%74%68=` and all other mixed encoded/literal variants.

### Immediate Mitigation
The fix has been applied manually to the live cluster (ConfigMap patched + deployment restarted) while this PR is in review.