### PR TITLE
zitadel(prod+preprod): harden FirstInstance LoginPolicy (no self-register, force MFA)

### DIFF
--- a/kubernetes/helm_charts/local/zitadel/values-preprod.yaml
+++ b/kubernetes/helm_charts/local/zitadel/values-preprod.yaml
@@ -51,6 +51,21 @@ configData: |
   FirstInstance:
     Skip: false
     InstanceName: "eco-preprod"
+    # Harden the default login policy: disable self-registration so
+    # unauthenticated visitors cannot create users in the org.
+    # NOTE: FirstInstance only applies at initial `zitadel setup`. For an
+    # already-bootstrapped instance, also change the live Login Policy via
+    # Console (Settings > Login Behavior and Security > "Register allowed")
+    # or the Admin/Management API (allowRegister: false). Separately, the
+    # external IdP option "Account creation allowed (manually)"
+    # (isCreationAllowed) and "Automatic creation" (isAutoCreation) must be
+    # disabled on the running instance/org — those are runtime-only and
+    # cannot be expressed here.
+    LoginPolicy:
+      AllowUsernamePassword: true
+      AllowRegister: false
+      AllowExternalIDP: true
+      ForceMFA: true
     # Pre-configure the first admin user
     Org:
       LoginClient:

--- a/kubernetes/helm_charts/local/zitadel/values-prod.yaml
+++ b/kubernetes/helm_charts/local/zitadel/values-prod.yaml
@@ -51,6 +51,21 @@ configData: |
   FirstInstance:
     Skip: false
     InstanceName: "eco"
+    # Harden the default login policy: disable self-registration so
+    # unauthenticated visitors cannot create users in the org.
+    # NOTE: FirstInstance only applies at initial `zitadel setup`. For an
+    # already-bootstrapped instance, also change the live Login Policy via
+    # Console (Settings > Login Behavior and Security > "Register allowed")
+    # or the Admin/Management API (allowRegister: false). Separately, the
+    # external IdP option "Account creation allowed (manually)"
+    # (isCreationAllowed) and "Automatic creation" (isAutoCreation) must be
+    # disabled on the running instance/org — those are runtime-only and
+    # cannot be expressed here.
+    LoginPolicy:
+      AllowUsernamePassword: true
+      AllowRegister: false
+      AllowExternalIDP: true
+      ForceMFA: true
     Org:
       LoginClient:
         Machine:


### PR DESCRIPTION
## Summary

Harden the ZITADEL `FirstInstance` login policy for both **prod** and **preprod** so a fresh instance bootstrap is secure by default.

Adds an explicit `LoginPolicy` under `FirstInstance` in:
- `kubernetes/helm_charts/local/zitadel/values-prod.yaml`
- `kubernetes/helm_charts/local/zitadel/values-preprod.yaml`

```yaml
LoginPolicy:
  AllowUsernamePassword: true
  AllowRegister: false      # block unauthenticated self-registration
  AllowExternalIDP: true
  ForceMFA: true            # enforce a second factor
```

## Why

ZITADEL's built-in default login policy has `AllowRegister: true` and `ForceMFA: false`. Because our `FirstInstance` block did not specify a `LoginPolicy`, those insecure defaults applied, allowing unauthenticated visitors to self-register users in the org.

## Important notes / follow-up (runtime-only, not in this PR)

- `FirstInstance` config applies **only at the initial `zitadel setup`**. It does **not** change the already-bootstrapped prod/preprod instances. The running instances must be changed via the Console (Settings -> Login Behavior and Security) or the Admin/Management API.
- The actual self-registration observed is driven by the external **IdP** option **"Account creation allowed (manually)"** (`isCreationAllowed`) and **"Automatic creation"** (`isAutoCreation`). These are **runtime-only** (cannot be expressed in Helm values) and must be disabled in Console -> Settings -> Identity Providers -> the IdP, at both org and instance-default level.
- `ForceMFA: true` on a fresh bootstrap requires the admin user to enroll an MFA method or risk lockout.

## Test plan

- [x] YAML validates (no lint errors).
- [ ] Verify on next fresh instance bootstrap that registration is disabled and MFA is enforced.
- [ ] Manually disable IdP isCreationAllowed / isAutoCreation on the live prod + preprod instances via Console.
