### PR TITLE
vault: disable public ingress, keep in-cluster ArgoCD access

### DIFF
--- a/kubernetes/helm_charts/upstream/vault/values-prod.yaml
+++ b/kubernetes/helm_charts/upstream/vault/values-prod.yaml
@@ -51,9 +51,12 @@ vault:
         memory: 1Gi
         cpu: 500m
 
-    # Ingress configuration for external access
+    # Ingress DISABLED: Vault is not publicly exposed. In-cluster consumers
+    # (e.g. ArgoCD AVP in argocd-k8s) reach it via the internal ClusterIP
+    # service vault-otcinfra2.vault.svc.cluster.local:8200. Re-enable only if
+    # external access is explicitly required.
     ingress:
-      enabled: true
+      enabled: false
       ingressClassName: "nginx"
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-prod
@@ -252,9 +255,11 @@ vault:
           }
 
     # Additional environment variables (must be under server: for the chart to use them)
+    # VAULT_API_ADDR advertises the internal ClusterIP service (public ingress
+    # is disabled); matches the raft api_addr above so HA redirects stay in-cluster.
     extraEnvironmentVars:
       VAULT_ADDR: "https://127.0.0.1:8200"
-      VAULT_API_ADDR: "https://vault-k8s.eco.tsi-dev.otc-service.com"
+      VAULT_API_ADDR: "https://vault-otcinfra2.vault.svc.cluster.local:8200"
       VAULT_CACERT: "/vault/tls/ca.crt"
 
     # Standalone configuration (disabled in favor of HA)


### PR DESCRIPTION
Disables public access to Vault (otcinfra2) while keeping in-cluster consumers working.

## What changed
`kubernetes/helm_charts/upstream/vault/values-prod.yaml`:
1. `vault.server.ingress.enabled: true → false` — removes the only public exposure (nginx Ingress `vault-k8s.eco.tsi-dev.otc-service.com`). The Vault Service is `ClusterIP` only.
2. `VAULT_API_ADDR` repointed from the public URL to the internal service `https://vault-otcinfra2.vault.svc.cluster.local:8200` (matches the raft `api_addr`), so nothing advertises the dead public URL and HA redirects stay in-cluster.

## Why ArgoCD is unaffected
Verified against the live cluster: all AVP containers in `argocd-otcinfra2-repo-server` (`repo-server`, `avp`, `avp-with-args`, `avp-kustomize`) already reach Vault via the internal service with Kubernetes auth (`VAULT_ADDR=https://vault-otcinfra2.vault.svc.cluster.local:8200`, role `argocd`, mount `auth/kubernetes_otcinfra2`) — never the public ingress. The `argocd-k8s` namespace is already in Vault's NetworkPolicy consumers. Internal raft TLS (`vault-server-tls`) is separate from the ingress cert (`vault-tls-cert`), so it is untouched.

## Rollout notes
- App `vault-otcinfra2` syncs this path with `automated: {prune: true, selfHeal: true}` → on sync ArgoCD auto-prunes the Ingress (and its cert-manager Certificate) and rolls the statefulset for the new `VAULT_API_ADDR` (auto-unseal sidecar re-unseals each pod).
- Post-sync check: Ingress `vault-otcinfra2` gone, public URL no longer serves Vault, ArgoCD apps still render (AVP secret resolution healthy).