### PR TITLE
loki: extend minio persistence 400Gi -> 800Gi

### DIFF
--- a/playbooks/templates/charts/loki/loki-values.yaml.j2
+++ b/playbooks/templates/charts/loki/loki-values.yaml.j2
@@ -121,7 +121,7 @@ minio:
   enabled: true
   rootPassword: "{{ chart.loki_minio_root_password }}"
   persistence:
-    size: 400Gi
+    size: 800Gi
     storageClass: csi-disk-retain
   resources:
     requests:


### PR DESCRIPTION
The Loki embedded **minio** object store (cluster `otcinfra`, namespace `loki`) was provisioned at **400Gi** per drive and `export-0-loki-minio-0` reached **99%** usage.

Both drive PVCs (`export-0`/`export-1-loki-minio-0`, storageClass `csi-disk-retain`, `allowVolumeExpansion: true`) were expanded **online to 800Gi** via the everest CSI (resize2fs, no pod restart, no downtime — `loki-minio-0` stayed `Running`). export-0 dropped from 99% → 50%.

This updates the helm values source (`playbooks/templates/charts/loki/loki-values.yaml.j2`, `minio.persistence.size`) so the size is codified and future deploys match the live state.

> Note: the minio StatefulSet `volumeClaimTemplate` is immutable in-place and still reads 400Gi; it only affects *new* replicas (minio runs single-replica, so no impact).