### PR TITLE
zuul(eco2): switch zuul-infra load-branch to main

### DIFF
--- a/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
+++ b/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
@@ -22,7 +22,7 @@
                 - pipeline
                 - nodeset
                 - secret
-              load-branch: Migration_of_zuul_to_prod
+              load-branch: main
         untrusted-projects:
           - opentelekomcloud-infra/system-config:
               include:


### PR DESCRIPTION
Migration_of_zuul_to_prod merged into main (zuul-infra PR #1). Point eco2 tenant load-branch at main so default_branch=main resolves and rancher driver-job checkouts stop erroring with 'does not have the default branch main'. Config content is identical (main == Migration + merge).