### PR TITLE
swift-proxy(preprod): gate Zuul log reads behind Zitadel oauth

### DIFF
--- a/kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-configmap.yaml
+++ b/kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-configmap.yaml
@@ -6,6 +6,104 @@ metadata:
   labels:
     {{- include "swift-proxy.labels" . | nindent 4 }}
 data:
+{{- if and .Values.urlRewriter.oauth .Values.urlRewriter.oauth.enabled }}
+  # OpenResty variant: log reads are gated by Zitadel (oauth2-proxy) and the
+  # Swift log container stays PRIVATE. Requests that already carry Swift
+  # credentials (executor uploads, Loki, ...) bypass Zitadel and are validated
+  # by Swift itself. Anonymous browser reads must authenticate via Zitadel;
+  # only then is a short-lived Swift service token injected so Swift serves.
+  nginx.conf: |
+    env SWIFT_USER;
+    env SWIFT_KEY;
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      lua_shared_dict swift_auth 1m;
+
+      init_by_lua_block {
+        _G.swift_user = os.getenv("SWIFT_USER") or ""
+        _G.swift_key  = os.getenv("SWIFT_KEY") or ""
+        _G.signin_url = "{{ .Values.urlRewriter.oauth.signinUrl }}"
+        _G.gate = function()
+          local h = ngx.req.get_headers()
+          -- Client already presents Swift credentials -> leave untouched;
+          -- Swift validates the token. This covers executor uploads and Loki.
+          if h["x-auth-token"] or h["x-storage-token"] or h["x-auth-user"] then
+            return
+          end
+          -- Enforce Zitadel via an oauth2-proxy subrequest (cookie is inherited).
+          local a = ngx.location.capture("/_oauth_auth")
+          if not a or (a.status ~= 200 and a.status ~= 202) then
+            return ngx.redirect(_G.signin_url .. "?rd=https://" .. ngx.var.host .. ngx.var.request_uri)
+          end
+          -- Authenticated: inject a cached Swift service token for the read.
+          local tok = ngx.shared.swift_auth:get("token")
+          if not tok then
+            local res = ngx.location.capture("/_swift_auth")
+            if res and res.status == 200 then
+              tok = res.header["X-Auth-Token"] or res.header["X-Storage-Token"]
+              if tok then ngx.shared.swift_auth:set("token", tok, 43200) end
+            end
+          end
+          if tok then ngx.req.set_header("X-Auth-Token", tok) end
+        end
+      }
+
+      server {
+        listen 8081;
+
+        set_by_lua_block $swift_user { return _G.swift_user }
+        set_by_lua_block $swift_key  { return _G.swift_key }
+
+        # Internal: obtain a Swift tempauth token for the log-read account.
+        location = /_swift_auth {
+          internal;
+          proxy_pass http://{{ include "swift-proxy.fullname" . }}:{{ .Values.proxy.port }}/auth/v1.0;
+          proxy_set_header X-Auth-User $swift_user;
+          proxy_set_header X-Auth-Key $swift_key;
+          proxy_set_header Host $host;
+        }
+
+        # Internal: Zitadel authentication check via oauth2-proxy.
+        location = /_oauth_auth {
+          internal;
+          proxy_pass {{ .Values.urlRewriter.oauth.authUrl }};
+          proxy_pass_request_body off;
+          proxy_set_header Content-Length "";
+          proxy_set_header X-Original-URI $request_uri;
+          proxy_set_header Host $host;
+        }
+
+        # Remove trailing slash from index.html URLs - always redirect to HTTPS
+        location ~ ^(.*index\.html)/$ {
+          return 301 https://$host$1;
+        }
+
+        # Serve index.html for directory URLs (ending with /)
+        location ~ ^(.+)/$ {
+          access_by_lua_block { _G.gate() }
+          proxy_pass http://{{ include "swift-proxy.fullname" . }}:{{ .Values.proxy.port }}$1/index.html;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Proxy all other requests to Swift
+        location / {
+          access_by_lua_block { _G.gate() }
+          proxy_pass http://{{ include "swift-proxy.fullname" . }}:{{ .Values.proxy.port }};
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+      }
+    }
+{{- else }}
   nginx.conf: |
     events {
       worker_connections 1024;
@@ -39,4 +137,5 @@ data:
         }
       }
     }
+{{- end }}
 {{- end }}

--- a/kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-deployment.yaml
+++ b/kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-deployment.yaml
@@ -22,13 +22,26 @@ spec:
       - name: nginx
         image: {{ .Values.urlRewriter.image.repository }}:{{ .Values.urlRewriter.image.tag }}
         imagePullPolicy: {{ .Values.urlRewriter.image.pullPolicy }}
+        {{- if and .Values.urlRewriter.oauth .Values.urlRewriter.oauth.enabled }}
+        env:
+          - name: SWIFT_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "swift-proxy.fullname" . }}-url-rewriter-auth
+                key: SWIFT_USER
+          - name: SWIFT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "swift-proxy.fullname" . }}-url-rewriter-auth
+                key: SWIFT_KEY
+        {{- end }}
         ports:
         - name: http
           containerPort: 8081
           protocol: TCP
         volumeMounts:
         - name: nginx-config
-          mountPath: /etc/nginx/nginx.conf
+          mountPath: {{ .Values.urlRewriter.configPath | default "/etc/nginx/nginx.conf" }}
           subPath: nginx.conf
         resources:
           {{- toYaml .Values.urlRewriter.resources | nindent 10 }}

--- a/kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-secret.yaml
+++ b/kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.urlRewriter.enabled .Values.urlRewriter.oauth .Values.urlRewriter.oauth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "swift-proxy.fullname" . }}-url-rewriter-auth
+  labels:
+    {{- include "swift-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: url-rewriter
+type: Opaque
+stringData:
+  # Swift tempauth credentials for the log-read service account. The
+  # url-rewriter uses these to fetch a short-lived Swift token that is
+  # injected into browser reads AFTER Zitadel authentication succeeds.
+  # Values are resolved by the ArgoCD Vault Plugin.
+  SWIFT_USER: {{ .Values.urlRewriter.swiftAuth.username | quote }}
+  SWIFT_KEY: {{ .Values.urlRewriter.swiftAuth.password | quote }}
+{{- end }}

--- a/kubernetes/helm_charts/local/swift-proxy/values-preprod.yaml
+++ b/kubernetes/helm_charts/local/swift-proxy/values-preprod.yaml
@@ -247,18 +247,34 @@ probes:
     initialDelaySeconds: 5
     periodSeconds: 5
 
-# URL Rewriter - nginx proxy that fixes trailing slash issue
+# URL Rewriter - reverse proxy in front of Swift for Zuul log browsing.
+# On preprod it runs OpenResty and gates reads behind Zitadel (oauth2-proxy)
+# while keeping the log container PRIVATE (no public-read ACL). Executor
+# uploads and other token-bearing clients bypass Zitadel and are validated
+# by Swift itself; authenticated browser reads get a short-lived Swift token
+# injected server-side.
 urlRewriter:
   enabled: true
   replicaCount: 2
   image:
-    repository: nginx
-    tag: "1.27-alpine"
+    repository: openresty/openresty
+    tag: "1.27.1.2-alpine"
     pullPolicy: IfNotPresent
+  configPath: /usr/local/openresty/nginx/conf/nginx.conf
+  oauth:
+    enabled: true
+    # In-cluster oauth2-proxy auth endpoint (validates the Zitadel cookie).
+    authUrl: "http://zuul-oauth-proxy.zuul.svc.cluster.local:4180/oauth2/auth"
+    # Public oauth2-proxy sign-in endpoint browsers are redirected to.
+    signinUrl: "https://zuul-oauth2-proxy.eco-preprod.tsi-dev.otc-service.com/oauth2/start"
+  # Swift tempauth service account used to fetch a read token (AVP-resolved).
+  swiftAuth:
+    username: "zuul-preprod-logs:<path:secret/data/swift/users/zuul#username>"
+    password: "<path:secret/data/swift/users/zuul#password>"
   resources:
     requests:
       cpu: "50m"
       memory: "64Mi"
     limits:
-      cpu: "100m"
-      memory: "128Mi"
+      cpu: "200m"
+      memory: "256Mi"


### PR DESCRIPTION
## Problem
Zuul build-log links (e.g. `https://swift-proxy.eco-preprod…/v1/AUTH_zuul-preprod-logs/…`) return **HTTP 401**: the Kolla swift-proxy serves the log container via tempauth only, with no oauth/anonymous read path.

## Requirement
Logs must **not** be public-read; access **only** via **Zitadel** oauth.

## Change
Convert the preprod `url-rewriter` (nginx → OpenResty) into a Zitadel-gated reverse proxy in front of Swift:
- **Browser reads** are gated by the existing `zuul-oauth-proxy` (Zitadel) via an in-cluster `/oauth2/auth` subrequest; unauthenticated users are redirected to `/oauth2/start`. After auth, a short-lived Swift service token (fetched with the `zuul-preprod-logs` tempauth creds, cached ~12h) is injected so Swift serves the **still-private** container. **No `.r:*` public-read ACL.**
- **Token-bearing requests** (executor uploads, Loki, …) **bypass** Zitadel and are validated by Swift itself → uploads keep working on the same host, returned `log_url` unchanged. A forged token can't leak logs (Swift rejects it; the service token is only injected after Zitadel auth on tokenless requests).

Gated behind `urlRewriter.oauth.enabled`, so **prod rendering is unchanged**.

## Files
- `kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-configmap.yaml`
- `kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-deployment.yaml`
- `kubernetes/helm_charts/local/swift-proxy/templates/url-rewriter-secret.yaml` (new)
- `kubernetes/helm_charts/local/swift-proxy/values-preprod.yaml`

## Validation
- `helm template` renders cleanly for preprod (OpenResty + lua gate + AVP secret) and, with oauth disabled, falls back to the original nginx passthrough (no secret/env) — prod unaffected.