### PR TITLE
fix(zuul): eco2 tenant — load private repos (exclude-unprotected-branches=false)

### DIFF
--- a/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
+++ b/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
@@ -23,11 +23,21 @@
                 - nodeset
                 - secret
               load-branch: Migration_of_zuul_to_prod
+              # Repo is private on a Free plan, so branch protection is
+              # unavailable and every branch reports as unprotected. Disable
+              # exclude-unprotected-branches here so the executor can check out
+              # the load-branch (otherwise checkoutTrustedProject fails and all
+              # jobs die with RETRY_LIMIT).
+              exclude-unprotected-branches: false
         untrusted-projects:
           - opentelekomcloud-infra/system-config:
               include:
                 - project
               shadow: opentelekomcloud-infra/system-config
+              # Private repo (see zuul-infra note above): branch protection is
+              # unavailable, so do not exclude unprotected branches or the
+              # project config would stop loading.
+              exclude-unprotected-branches: false
           - opentelekomcloud/LoveOTC:
               include:
                 - project


### PR DESCRIPTION
## Problem
eco2 CI is fully broken: every job for any change dies in setup with `RETRY_LIMIT` and no logs, so GitHub checks (e.g. PR #1654 `eco2/check`) stay stuck **pending** — looks like "jobs not triggered at all".

Executor error:
```
checkoutTrustedProject -> merger.checkoutBranch(Migration_of_zuul_to_prod)
ValueError: Could not extract object from Migration_of_zuul_to_prod
```

## Root cause
`zuul-infra` (config-project) and `system-config` were made **private**. On this org's GitHub **Free** plan, branch protection/rulesets require a public repo (`gh api .../protection` -> 403 *Upgrade to GitHub Pro or make this repository public*), so going private **silently dropped all branch protection** — every branch now reports as unprotected.

The eco2 tenant has tenant-wide `exclude-unprotected-branches: true`, so the executor filters out the config-project's `load-branch: Migration_of_zuul_to_prod`, cannot check it out, and every job fails. The scheduler kept enqueueing only because it holds stale cached config.

## Fix
Override `exclude-unprotected-branches: false` per-project for the two now-private `opentelekomcloud-infra` repos (`zuul-infra`, `system-config`). Public projects keep the tenant default. This mirrors the already-working **preprod** tenant, which uses no `exclude-unprotected-branches` + explicit branch pinning.

Note: `include-branches`/`exclude-branches` can only *reduce* the branch set (they run after `exclude-unprotected-branches`), so `exclude-unprotected-branches: false` is the only lever that re-includes the unprotected branch.