### PR TITLE
fix(zuul): eco2 tenant load zuul-infra from main + exclude-unprotected-branches=false

### DIFF
--- a/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
+++ b/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
@@ -35,12 +35,22 @@
                 - pipeline
                 - nodeset
                 - secret
-              load-branch: Migration_of_zuul_to_prod
+              load-branch: main
+              # zuul-infra is private on a GitHub Free plan, so branch
+              # protection is unavailable and every branch (including main)
+              # reports as unprotected. Disable exclude-unprotected-branches
+              # here so the executor can check out the load-branch; otherwise
+              # checkoutTrustedProject fails and all jobs die with RETRY_LIMIT.
+              exclude-unprotected-branches: false
         untrusted-projects:
           - opentelekomcloud-infra/system-config:
               include:
                 - project
               shadow: opentelekomcloud-infra/system-config
+              # Private repo (see zuul-infra note above): branch protection is
+              # unavailable, so do not exclude unprotected branches or the
+              # project config would stop loading.
+              exclude-unprotected-branches: false
           - opentelekomcloud/LoveOTC:
               include:
                 - project

--- a/kubernetes/kustomize/zuul/overlays/prod/kustomization.yaml
+++ b/kubernetes/kustomize/zuul/overlays/prod/kustomization.yaml
@@ -16,7 +16,7 @@ configMapGenerator:
     behavior: replace
     literals:
       - ZUUL_CONFIG_REPO=https://github.com/opentelekomcloud-infra/zuul-infra/
-      - ZUUL_CONFIG_BRANCH=Migration_of_zuul_to_prod
+      - ZUUL_CONFIG_BRANCH=main
   - name: "nodepool-config-yaml"
     files:
       - "configs/nodepool.yaml"


### PR DESCRIPTION
Deploys the eco2 CI outage fix on the branch the zuul-otcinfra2 ArgoCD app actually tracks (`Zuul_job_migration_fixes`, path `overlays/prod`).

- config-project `zuul-infra`: `load-branch` + `ZUUL_CONFIG_BRANCH` -> **main** (zuul-infra main fast-forwarded to include today's real image build/upload jobs).
- Add `exclude-unprotected-branches: false` per-project for the two private `opentelekomcloud-infra` repos. Required because the repos are private on GitHub Free, so branch protection is unavailable and every branch (incl. main) reports unprotected; with the tenant-wide `exclude-unprotected-branches: true` the executor filtered out the config-project branch -> `checkoutTrustedProject` failed -> all jobs `RETRY_LIMIT`.