### PR TITLE
fix(zuul): restrict eco2 system-config config loading to main

### DIFF
--- a/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
+++ b/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
@@ -51,6 +51,12 @@
               # unavailable, so do not exclude unprotected branches or the
               # project config would stop loading.
               exclude-unprotected-branches: false
+              # system-config has hundreds of branches; without this,
+              # exclude-unprotected-branches: false would make Zuul parse
+              # config from every branch (slow reconfigure, empty layout).
+              # Restrict prod config loading to main only.
+              include-branches:
+                - main
           - opentelekomcloud/LoveOTC:
               include:
                 - project


### PR DESCRIPTION
Follow-up to the exclude-unprotected-branches fix. system-config has hundreds of branches; with exclude-unprotected-branches: false and no include-branches, Zuul parsed config from every branch (~980 loads), thrashing the reconfigure and leaving the eco2 tenant with zero pipelines. Restrict to main only.