### PR TITLE
chore(argocd): align eco2 zuul app targetRevision with live (Zuul_job_migration_fixes)

### DIFF
--- a/kubernetes/helm_charts/local/argocd/values/prod/values-argocd-applications.yaml
+++ b/kubernetes/helm_charts/local/argocd/values/prod/values-argocd-applications.yaml
@@ -302,7 +302,10 @@ applications:
     config:
       namespace: zuul
       repoURL: 'https://github.com/opentelekomcloud-infra/system-config.git'
-      targetRevision: 'main'
+      # eco2/prod Zuul is deployed from the migration working branch, not
+      # main, during the eco->eco2 migration. Keep this aligned with the
+      # live zuul-otcinfra2 ArgoCD app (argocd-k8s namespace).
+      targetRevision: 'Zuul_job_migration_fixes'
       path: kubernetes/kustomize/zuul/overlays/prod/
       pluginName: argocd-vault-plugin-kustomize
       pluginEnv: '.'


### PR DESCRIPTION
The live zuul-otcinfra2 ArgoCD app (argocd-k8s ns) deploys overlays/prod from Zuul_job_migration_fixes, but values-argocd-applications.yaml declared main. Align source of truth with reality.