### PR TITLE
fix(argocd): disable Helm CRD management to avoid 262144B annotation limit

### DIFF
--- a/playbooks/templates/charts/argocd/argocd-values.yaml.j2
+++ b/playbooks/templates/charts/argocd/argocd-values.yaml.j2
@@ -5,7 +5,16 @@ createAggregateRoles: false
 createClusterRoles: true
 
 crds:
-  install: true
+  # argo-cd's Application/ApplicationSet CRDs exceed the 262144-byte Kubernetes
+  # annotation limit (applications ~401KB, applicationsets ~1.38MB). Helm 3 uses
+  # client-side apply, which stores the whole object in the
+  # kubectl.kubernetes.io/last-applied-configuration annotation and therefore
+  # FAILS on upgrade with: metadata.annotations: Too long: must have at most
+  # 262144 bytes. Do NOT let Helm manage the CRDs; apply them out-of-band with
+  # `kubectl apply --server-side --force-conflicts` (SSA does not use that
+  # annotation). The live CRDs already carry helm.sh/resource-policy: keep, so
+  # Helm will not delete them when install=false.
+  install: false
   keep: true
 
 dex:


### PR DESCRIPTION
## Problem
The `install-helm-chart` playbook fails deploying argo-cd on **otcinfra2** (`argocd` ns) with `rc=2`. Root cause: the argo-cd CRDs are far larger than the Kubernetes **262144-byte annotation limit**:

| CRD | rendered size |
|-----|---------------|
| `applications.argoproj.io` | ~401 KB |
| `applicationsets.argoproj.io` | ~1.38 MB |
| `appprojects.argoproj.io` | ~17 KB |

Helm 3 uses **client-side apply**, which stores the whole object in the `kubectl.kubernetes.io/last-applied-configuration` annotation. On upgrade this exceeds the limit:

```
CustomResourceDefinition ... metadata.annotations: Too long: must have at most 262144 bytes
```

This is why `helm ... --dry-run=server` passes (server-side apply doesn't use that annotation) but the real `helm upgrade` run by `kubernetes.core.helm` fails.

## Fix
Set `crds.install: false` in the argo-cd values template so Helm no longer manages/applies the CRDs. The CRDs are applied out-of-band with `kubectl apply --server-side --force-conflicts` (SSA is not subject to the annotation limit).

## Safety
- The live CRDs already carry `helm.sh/resource-policy: keep`, so Helm will **not** delete them when `install=false` (verified on otcinfra2).
- Blast radius protected: **95 Applications**, **12 AppProjects**.
- CRDs remain `managed-by=Helm rel=argocd/argocd` (kept).

## Follow-up
One-time server-side apply of the v3.4.5 CRDs to bring schemas current:
```
kubectl apply --server-side --force-conflicts -f <argo-cd 10.2.1 CRDs>
```

Companion to #1662 (argo-cd chart 8.0.13 → 10.2.1 upgrade); rebase #1662 onto this.