### PR TITLE
fix(zuul): doc-convertor dynamic config from unprotected PR branches (eco2)

### DIFF
--- a/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
+++ b/kubernetes/kustomize/zuul/overlays/prod/configs/tenants/main.yaml
@@ -961,6 +961,19 @@
               include:
                 - job
                 - project
+                - nodeset
+              # This repo lives on the new gitea (gitea-k8s) where private
+              # repos have no branch protection, so feature/PR branches report
+              # as unprotected. With the tenant default
+              # exclude-unprotected-branches: true, Zuul refuses to load in-repo
+              # config from unprotected branches - including a PR's proposed
+              # .zuul.yaml - so dynamic (speculative) config changes (e.g. a
+              # nodeset switch ubuntu-jammy -> zuul-debian) are silently ignored
+              # and jobs run with the config from the protected main branch.
+              # Disable the exclusion so Zuul loads config from PR branches and
+              # dynamic configuration works. 'nodeset' is added to include so a
+              # standalone nodeset object in the repo is not stripped.
+              exclude-unprotected-branches: false
           - docs/doc-exports:
               include:
                 - project


### PR DESCRIPTION
## Problem
Testing PR docs/doc-convertor#32 on the new gitea (gitea-k8s), Zuul ignores the `zuul.yaml` changes and still uses the old `ubuntu-jammy` nodeset instead of `zuul-debian`, even though the repo is untrusted (dynamic config should apply).

## Root cause (verified on live eco2)
- The convertor job is defined in `docs/doc-convertor` **branch main** (`zuul.yaml`); `ubuntu-jammy` comes from the parent chain up to `otc-tox` in `zuul-infra`.
- The eco2 tenant has **`exclude-unprotected-branches: true`** (tenant default) and the gitea source does **not** override it.
- On the new gitea, private repos have **no branch protection**, so a PR's feature branch is **unprotected**. With `exclude-unprotected-branches: true`, Zuul refuses to load in-repo config from unprotected branches — including the PR's proposed `zuul.yaml`. So the speculative/dynamic config change is dropped and jobs run with the config from the protected `main` branch (old nodeset).

This is the same private-repo/branch-protection failure mode that broke eco2/eco job loading; the fix mirrors the existing `exclude-unprotected-branches: false` overrides for the private GitHub config-projects `zuul-infra` and `system-config`.

## Fix
For `docs/doc-convertor` in the eco2 tenant:
- `exclude-unprotected-branches: false` → Zuul loads config from PR/feature branches → dynamic config applies.
- add `nodeset` to `include` so a standalone `nodeset` object in the repo is not stripped (include previously only allowed `job, project`).

## Notes
- Base branch is `Zuul_job_migration_fixes` because that is the branch ArgoCD app `zuul-otcinfra2` currently deploys (verified: targetRevision).
- Ensure the `zuul-debian` label exists in the eco2 nodepool, or the job will fail to get a node.
- If this proves correct, consider applying the same override to the whole gitea docs source (all private docs repos have the same limitation).