### PR TITLE
loki: disable minio fsGroup to fix mount hang on 800G volume

### DIFF
--- a/playbooks/templates/charts/loki/loki-values.yaml.j2
+++ b/playbooks/templates/charts/loki/loki-values.yaml.j2
@@ -120,6 +120,18 @@ gateway:
 minio:
   enabled: true
   rootPassword: "{{ chart.loki_minio_root_password }}"
+  # fsGroup is disabled on purpose. With fsGroup set, kubelet recursively
+  # chowns the ENTIRE ~800G MinIO dataset (millions of chunk files) on every
+  # mount (see kubernetes/kubernetes#69699). That walk exceeds kubelet's
+  # 2-minute volume-mount deadline, so the pod loops forever in
+  # ContainerCreating ("context deadline exceeded"). fsGroupChangePolicy:
+  # OnRootMismatch is NOT honoured by the CCE kubelet fork. MinIO already runs
+  # as uid/gid 1000 and its data is group 1000, so fsGroup is unnecessary.
+  securityContext:
+    enabled: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: null
   persistence:
     size: 800Gi
     storageClass: csi-disk-retain


### PR DESCRIPTION
## Problem
The nightly `install-helm-chart` deploy left `loki-minio-0` stuck in `ContainerCreating`. Root cause: with `securityContext.fsGroup: 1000`, kubelet recursively `chown`s the entire ~800G MinIO dataset (millions of chunk files) on every mount ([kubernetes/kubernetes#69699](https://github.com/kubernetes/kubernetes/issues/69699)). That walk exceeds kubelet's 2-minute volume-mount deadline → `context deadline exceeded` → infinite retry → pod never starts. `fsGroupChangePolicy: OnRootMismatch` is **not honoured** by the CCE kubelet fork (v1.28.13-r0).

## Fix
Set `minio.securityContext.fsGroup: null` so kubelet does no ownership management. MinIO already runs as `runAsUser/runAsGroup=1000` and its data is group 1000, so fsGroup is unnecessary.

## Context
The live `loki-minio` StatefulSet was already hot-patched (fsGroup removed) and is `1/1 Running` at 800Gi. This PR makes the fix permanent so the next nightly helm upgrade does not re-apply `fsGroup: 1000` and re-break the pod.

⚠️ Should merge before the next nightly run.